### PR TITLE
Refactor EUX controller endpoints to use FrontendResponse

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,51 +82,52 @@ The app uses NAV's design system: `@navikt/ds-react` for components, `@navikt/ds
 
 `src/*` is aliased to `./src/*` in both tsconfig and Vite config, so imports use `src/actions/buc` rather than relative paths.
 
-## Git Commit Messages — Arlo's Commit Notation
+## Git Commit Messages — Arlo's Commit Notation (Modified)
 
-All commits in this repository **must** use [Arlo's Commit Notation](https://github.com/RefactoringCombos/ArlosCommitNotation). Each commit message starts with a risk–intention prefix followed by a short summary.
+All commits in this repository **must** use our modified version of [Arlo's Commit Notation](https://github.com/RefactoringCombos/ArlosCommitNotation). Each commit message starts with an intention prefix, a risk separator, and a short summary.
 
 ### Format
 
 ```
-<risk><intention> <Short summary>
+<intention><risk separator> <Short summary>
 ```
 
-### Risk levels
+### Risk separators
 
-| Symbol | Meaning | Description |
-|--------|---------|-------------|
-| `.` | Proven safe | Addresses all known **and** unknown risks (e.g., automated refactoring) |
-| `^` | Validated | Addresses all known risks (e.g., tested manually or by CI) |
-| `!` | Risky | Some known risks remain unverified |
-| `@` | Probably broken | Incomplete or untested — may not work |
+| Separator | Meaning | Example |
+|-----------|---------|---------|
+| ` - ` | Proven safe | `r - Extract method calculatePension` |
+| `! - ` | Risky | `R! - Refactor auth flow` |
+| `!! ` | Very risky | `F!! Add untested SED editor` |
 
 ### Intention prefixes
 
+Use **lowercase** for safe, non-behaviour-changing work. Use **UPPERCASE** for behaviour-impacting or higher-risk work.
+
 | Prefix | Meaning | Description |
 |--------|---------|-------------|
-| `F` | Feature | Changes or extends one aspect of program behaviour |
-| `B` | Bugfix | Repairs undesirable behaviour without altering others |
-| `R` | Refactoring | Changes implementation without changing behaviour |
-| `D` | Documentation | Changes documentation or comments only |
-| `E` | Environment | Changes build, CI, dependencies, or tooling |
-| `T` | Test | Adds or modifies tests only |
+| `f/F` | Feature | Changes or extends one aspect of program behaviour |
+| `b/B` | Bugfix | Repairs undesirable behaviour without altering others |
+| `r/R` | Refactoring | Changes implementation without changing behaviour |
+| `d/D` | Documentation | Changes documentation or comments only |
+| `e/E` | Environment | **Manual** changes to build, CI, dependencies, or tooling |
+| `u/U` | Update | **Automatic** bumps and environment updates (auto-merge, dependency bots) |
+| `t/T` | Test | Adds or modifies tests only |
 
 ### Examples
 
 ```
-.R Extract method calculatePension
-^F Add password reset feature
-!B Fix intermittent crash on login
-@F Start implementing new SED editor
-.D Update README with build instructions
-.E Upgrade React to v19
-.T Add missing unit tests for buc reducer
+r - Extract method calculatePension
+R! - Refactor EUX controller endpoints to use FrontendResponse
+F!! Add untested SED editor
+b - Fix null check in country filter
+d - Update README with build instructions
+e - Upgrade React to v19
+u - Auto-bump @navikt/ds-react to 7.2.0
+t - Add missing unit tests for buc reducer
 ```
 
 ### Rules
 
-- The prefix is **mandatory** on every commit.
-- Use lowercase `r`, `d`, `e`, `t` for non-behaviour-changing work; uppercase `F`, `B`, `R` for behaviour-impacting work — follow the table above.
-- Keep the summary concise and descriptive.
+- The prefix and risk separator are **mandatory** on every commit.
 - When multiple intentions apply, use the **riskiest** one.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,3 +81,52 @@ The app uses NAV's design system: `@navikt/ds-react` for components, `@navikt/ds
 ### Path aliases
 
 `src/*` is aliased to `./src/*` in both tsconfig and Vite config, so imports use `src/actions/buc` rather than relative paths.
+
+## Git Commit Messages — Arlo's Commit Notation
+
+All commits in this repository **must** use [Arlo's Commit Notation](https://github.com/RefactoringCombos/ArlosCommitNotation). Each commit message starts with a risk–intention prefix followed by a short summary.
+
+### Format
+
+```
+<risk><intention> <Short summary>
+```
+
+### Risk levels
+
+| Symbol | Meaning | Description |
+|--------|---------|-------------|
+| `.` | Proven safe | Addresses all known **and** unknown risks (e.g., automated refactoring) |
+| `^` | Validated | Addresses all known risks (e.g., tested manually or by CI) |
+| `!` | Risky | Some known risks remain unverified |
+| `@` | Probably broken | Incomplete or untested — may not work |
+
+### Intention prefixes
+
+| Prefix | Meaning | Description |
+|--------|---------|-------------|
+| `F` | Feature | Changes or extends one aspect of program behaviour |
+| `B` | Bugfix | Repairs undesirable behaviour without altering others |
+| `R` | Refactoring | Changes implementation without changing behaviour |
+| `D` | Documentation | Changes documentation or comments only |
+| `E` | Environment | Changes build, CI, dependencies, or tooling |
+| `T` | Test | Adds or modifies tests only |
+
+### Examples
+
+```
+.R Extract method calculatePension
+^F Add password reset feature
+!B Fix intermittent crash on login
+@F Start implementing new SED editor
+.D Update README with build instructions
+.E Upgrade React to v19
+.T Add missing unit tests for buc reducer
+```
+
+### Rules
+
+- The prefix is **mandatory** on every commit.
+- Use lowercase `r`, `d`, `e`, `t` for non-behaviour-changing work; uppercase `F`, `B`, `R` for behaviour-impacting work — follow the table above.
+- Keep the summary concise and descriptive.
+- When multiple intentions apply, use the **riskiest** one.

--- a/src/actions/admin.test.ts
+++ b/src/actions/admin.test.ts
@@ -24,7 +24,7 @@ describe('actions/admin', () => {
         success: types.ADMIN_RESEND_DOCUMENT_SUCCESS,
         failure: types.ADMIN_RESEND_DOCUMENT_FAILURE
       },
-      expectedPayload: { success: true },
+      expectedPayload: { result: { success: true } },
       cascadeFailureError: true,
       method: 'POST',
       url: sprintf(urls.ADMIN_RESEND_DOCUMENT_URL, { sakId: mockSakId, dokumentId: mockDokumentId })
@@ -39,7 +39,7 @@ describe('actions/admin', () => {
         success: types.ADMIN_RESEND_DOCUMENT_LIST_SUCCESS,
         failure: types.ADMIN_RESEND_DOCUMENT_LIST_FAILURE
       },
-      expectedPayload: { success: true },
+      expectedPayload: { result: { success: true } },
       cascadeFailureError: true,
       method: 'POST',
       url: sprintf(urls.ADMIN_RESEND_DOCUMENT_LISTE_URL)

--- a/src/actions/admin.ts
+++ b/src/actions/admin.ts
@@ -11,7 +11,7 @@ export const resendDocument = (
   return call({
     url: sprintf(urls.ADMIN_RESEND_DOCUMENT_URL, { sakId: sakId, dokumentId: dokumentId }),
     cascadeFailureError: true,
-    expectedPayload: { success: true },
+    expectedPayload: { result: { success: true } },
     method: 'POST',
     type: {
       request: types.ADMIN_RESEND_DOCUMENT_REQUEST,
@@ -27,7 +27,7 @@ export const resendDocumentList = (
   return call({
     url: sprintf(urls.ADMIN_RESEND_DOCUMENT_LISTE_URL),
     cascadeFailureError: true,
-    expectedPayload: { success: true },
+    expectedPayload: { result: { success: true } },
     method: 'POST',
     body: documentList,
     type: {

--- a/src/actions/buc.ts
+++ b/src/actions/buc.ts
@@ -319,7 +319,7 @@ export const getCountryList = (
     context: {
       buc: bucType
     },
-    expectedPayload: CountryFilter.EESSI_READY({}),
+    expectedPayload: { result: CountryFilter.EESSI_READY({}) },
     type: {
       request: types.BUC_GET_COUNTRY_LIST_REQUEST,
       success: types.BUC_GET_COUNTRY_LIST_SUCCESS,
@@ -346,7 +346,7 @@ export const getInstitutionsListForBucAndCountry = (
       buc: bucType,
       country
     },
-    expectedPayload: mockInstitutions,
+    expectedPayload: { result: mockInstitutions },
     type: {
       request: types.BUC_GET_INSTITUTION_LIST_REQUEST,
       success: types.BUC_GET_INSTITUTION_LIST_SUCCESS,
@@ -428,7 +428,7 @@ export const sendSed = (
     method: 'POST',
     cascadeFailureError: true,
     expectedPayload: {
-      success: 'true'
+      result: { success: 'true' }
     },
     type: {
       request: types.BUC_SEND_SED_REQUEST,
@@ -447,7 +447,7 @@ export const sendSedTo = (
     body: mottakere,
     cascadeFailureError: true,
     expectedPayload: {
-      success: 'true'
+      result: { success: 'true' }
     },
     type: {
       request: types.BUC_SEND_SED_REQUEST,
@@ -572,7 +572,7 @@ export const getRinaUrl = (
 ): ActionWithPayload<RinaUrlPayload> => {
   return call({
     url: urls.EUX_RINA_URL,
-    expectedPayload: mockRinaUrl,
+    expectedPayload: { result: mockRinaUrl },
     type: {
       request: types.BUC_RINA_GET_URL_REQUEST,
       success: types.BUC_RINA_GET_URL_SUCCESS,

--- a/src/reducers/buc.test.ts
+++ b/src/reducers/buc.test.ts
@@ -446,7 +446,7 @@ describe('reducers/buc', () => {
     expect(
       bucReducer(initialBucState, {
         type: types.BUC_GET_COUNTRY_LIST_SUCCESS,
-        payload: 'something'
+        payload: { result: 'something' }
       })
     ).toEqual({
       ...initialBucState,
@@ -492,7 +492,7 @@ describe('reducers/buc', () => {
         institutionNames: {}
       }, {
         type: types.BUC_GET_INSTITUTION_LIST_SUCCESS,
-        payload: mockPayload,
+        payload: { result: mockPayload },
         context: {
           buc: 'mockBucContext'
         }
@@ -644,7 +644,7 @@ describe('reducers/buc', () => {
       bucReducer(initialBucState, {
         type: types.BUC_RINA_GET_URL_SUCCESS,
         payload: {
-          rinaUrl: 'mockRinaUrl'
+          result: { rinaUrl: 'mockRinaUrl' }
         }
       })
     ).toEqual({

--- a/src/reducers/buc.ts
+++ b/src/reducers/buc.ts
@@ -569,7 +569,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
 
       return {
         ...state,
-        countryList: (action as ActionWithPayload).payload
+        countryList: (action as ActionWithPayload).payload.result
       }
 
     case types.BUC_GET_COUNTRY_LIST_REQUEST:
@@ -606,7 +606,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.BUC_GET_INSTITUTION_LIST_SUCCESS: {
       const institutionList: InstitutionListMap<Institution> = state.institutionList ? _.cloneDeep(state.institutionList!) : {}
       const institutionNames: InstitutionNames = _.clone(state.institutionNames);
-      (action as ActionWithPayload).payload.forEach((institution: Institution) => {
+      (action as ActionWithPayload).payload.result.forEach((institution: Institution) => {
         const existingInstitutions: Institutions = institutionList[institution.country] || []
         if (!_.find(existingInstitutions, { institution: institution.institution })) {
           existingInstitutions.push({
@@ -688,7 +688,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
 
       return {
         ...state,
-        rinaUrl: (action as ActionWithPayload).payload.rinaUrl
+        rinaUrl: (action as ActionWithPayload).payload.result.rinaUrl
       }
 
     case types.BUC_GET_P4000_REQUEST:


### PR DESCRIPTION
## Summary

Aligns EUX controller endpoints with the `FrontendResponse` pattern already used by `PersonController` (`PER_URL`). The backend now wraps responses in `{ result: <data> }`.

## Changes

**Actions** — wrap `expectedPayload` in `{ result: ... }`:
- `src/actions/buc.ts`: `getCountryList`, `getInstitutionsListForBucAndCountry`, `sendSed`, `sendSedTo`, `getRinaUrl`
- `src/actions/admin.ts`: `resendDocument`, `resendDocumentList`

**Reducers** — access `payload.result` instead of `payload`:
- `src/reducers/buc.ts`: `BUC_GET_COUNTRY_LIST_SUCCESS`, `BUC_GET_INSTITUTION_LIST_SUCCESS`, `BUC_RINA_GET_URL_SUCCESS`

**Tests** — updated payloads and assertions accordingly.

## Verification

- ✅ 444/444 tests pass
- ✅ TypeScript check clean
- ✅ Build succeeds

Closes #388