### PR TITLE
R! - Refactor BUC controller endpoints to use FrontendResponse

### DIFF
--- a/public/locales/nb/p8000.json
+++ b/public/locales/nb/p8000.json
@@ -69,7 +69,7 @@
   "atp-opprette-buc-or-sed": "Opprette {{BUC_SED}}",
   "atp-oppretter-buc-or-sed": "Oppretter {{BUC_SED}}",
   "atp-opprettet-buc-or-sed": "{{BUC_SED}} opprettet",
-  "atp-opprettelese-feilet-buc-or-sed": "Opprettelse av {{BUC_SED}} feilet",
+  "atp-opprettelse-feilet-buc-or-sed": "Opprettelse av {{BUC_SED}} feilet",
 
   "atp-hente-buc-or-sed": "Hente {{BUC_SED}}",
   "atp-henter-buc-or-sed": "Henter {{BUC_SED}}",

--- a/src/actions/buc.ts
+++ b/src/actions/buc.ts
@@ -73,7 +73,7 @@ export const createBuc = (
       kravDato: params.kravDato
     },
     cascadeFailureError: true,
-    expectedPayload: mockCreateBuc(params.buc),
+    expectedPayload: { result: mockCreateBuc(params.buc) },
     type: {
       request: types.BUC_CREATE_BUC_REQUEST,
       success: types.BUC_CREATE_BUC_SUCCESS,
@@ -89,7 +89,7 @@ export const createATPBuc = (
     url: sprintf(urls.BUC_CREATE_BUC_URL, { buc: params.buc }),
     method: 'POST',
     cascadeFailureError: true,
-    expectedPayload: mockCreateBuc(params.buc),
+    expectedPayload: { result: mockCreateBuc(params.buc) },
     type: {
       request: types.BUC_CREATE_ATP_BUC_REQUEST,
       success: types.BUC_CREATE_ATP_BUC_SUCCESS,
@@ -182,7 +182,7 @@ export const fetchBucsList = (
   return call({
     url: sprintf(urls.BUC_GET_BUCSLIST_URL, { aktoerId, sakId }),
     cascadeFailureError: true,
-    expectedPayload: mockBucs(aktoerId, sakId),
+    expectedPayload: { result: mockBucs(aktoerId, sakId) },
     context: {
       howManyBucLists
     },
@@ -228,7 +228,7 @@ export const  fetchBucsListWithAvdodFnr = (
   return call({
     url: sprintf(urls.BUC_GET_BUCSLIST_WITH_AVDODFNR_URL, { aktoerId, sakId, avdodFnr }),
     cascadeFailureError: true,
-    expectedPayload: mockBucs(aktoerId, sakId),
+    expectedPayload: { result: mockBucs(aktoerId, sakId) },
     type: {
       request: types.BUC_GET_BUCSLIST_REQUEST,
       success: types.BUC_GET_BUCSLIST_SUCCESS,
@@ -243,7 +243,7 @@ export const fetchBucsListWithVedtakId = (
   return call({
     url: sprintf(urls.BUC_GET_BUCSLIST_WITH_VEDTAKID_URL, { aktoerId, sakId, vedtakId }),
     cascadeFailureError: true,
-    expectedPayload: mockBucsWithVedtak(aktoerId, sakId),
+    expectedPayload: { result: mockBucsWithVedtak(aktoerId, sakId) },
     type: {
       request: types.BUC_GET_BUCSLIST_VEDTAK_REQUEST,
       success: types.BUC_GET_BUCSLIST_VEDTAK_SUCCESS,
@@ -277,7 +277,7 @@ export const fetchBuc = (
 
   return call({
     url,
-    expectedPayload: mockBuc(rinaCaseId),
+    expectedPayload: { result: mockBuc(rinaCaseId) },
     context: {
       rinaCaseId,
       aktoerId,
@@ -297,7 +297,7 @@ export const getBucOptions = (
 ): ActionWithPayload<BUCOptions> => {
   return call({
     url: sprintf(urls.BUC_GET_BUC_OPTIONS_URL),
-    expectedPayload: mockBucOptions,
+    expectedPayload: { result: mockBucOptions },
     context: {
       featureToggles,
       pesysContext,

--- a/src/actions/buc.ts
+++ b/src/actions/buc.ts
@@ -73,7 +73,7 @@ export const createBuc = (
       kravDato: params.kravDato
     },
     cascadeFailureError: true,
-    expectedPayload: { result: mockCreateBuc(params.buc) },
+    expectedPayload: mockCreateBuc(params.buc),
     type: {
       request: types.BUC_CREATE_BUC_REQUEST,
       success: types.BUC_CREATE_BUC_SUCCESS,

--- a/src/actions/buc.ts
+++ b/src/actions/buc.ts
@@ -89,7 +89,7 @@ export const createATPBuc = (
     url: sprintf(urls.BUC_CREATE_BUC_URL, { buc: params.buc }),
     method: 'POST',
     cascadeFailureError: true,
-    expectedPayload: { result: mockCreateBuc(params.buc) },
+    expectedPayload: mockCreateBuc(params.buc),
     type: {
       request: types.BUC_CREATE_ATP_BUC_REQUEST,
       success: types.BUC_CREATE_ATP_BUC_SUCCESS,

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -55,9 +55,10 @@ export const BUC_GET_BUCSLIST_WITH_VEDTAKID_URL = BUC_URL + '/rinasaker/%(aktoer
 export const BUC_GET_BUCSLIST_WITH_AVDODFNR_URL = BUC_URL + '/rinasaker/%(aktoerId)s/saknr/%(sakId)s/avdod/%(avdodFnr)s'
 export const BUC_GET_BUC_URL = BUC_URL + '/enkeldetalj/%(rinaCaseId)s'
 export const BUC_GET_BUC_WITH_AVDOD_URL = BUC_URL + '/enkeldetalj/%(rinaCaseId)s/aktoerid/%(aktoerId)s/saknr/%(sakId)s/avdodfnr/%(avdodFnr)s/kilde/%(kilde)s'
-
 export const BUC_GET_BUC_OPTIONS_URL = BUC_URL + '/bucs'
-export const BUC_CREATE_BUC_URL = BUC_URL + '/%(buc)s'
+
+//PrefillController
+export const BUC_CREATE_BUC_URL = BUC_URL + '/%(buc)s' //PREFILL CONTROLLER
 
 // PensjonController
 export const BUC_GET_KRAVDATO_URL = PEN_URL + '/kravdato/saker/%(sakId)s/krav/%(kravId)s/aktor/%(aktoerId)s'
@@ -65,8 +66,9 @@ export const BUC_GET_SAKTYPE_URL = PEN_URL + '/saktype/%(sakId)s/%(aktoerId)s'
 export const PERSON_UFT_URL = PEN_URL + '/vedtak/%(vedtakId)s/uforetidspunkt'
 
 // SedController
-export const BUC_CREATE_SED_URL = SED_URL + '/add'
-export const BUC_CREATE_REPLY_SED_URL = SED_URL + '/replysed/%(parentId)s'
+export const BUC_CREATE_SED_URL = SED_URL + '/add' //PREFILL CONTROLLER
+export const BUC_CREATE_REPLY_SED_URL = SED_URL + '/replysed/%(parentId)s' //PREFILL CONTROLLER
+
 export const BUC_GET_SED_LIST_URL = SED_URL + '/seds/%(buc)s/%(rinaId)s'
 export const BUC_GET_SED_URL = SED_URL + '/get/%(caseId)s/%(sedId)s'
 export const BUC_PUT_SED_URL = SED_URL + '/put/%(caseId)s/%(sedId)s'

--- a/src/reducers/buc.test.ts
+++ b/src/reducers/buc.test.ts
@@ -50,7 +50,7 @@ describe('reducers/buc', () => {
         bucs: {}
       }, {
         type: types.BUC_CREATE_BUC_SUCCESS,
-        payload: { caseId: '123', mockPayload: 'mockPayload' },
+        payload: { result: { caseId: '123', mockPayload: 'mockPayload' } },
         context: {
           person: {
             aktoer: {
@@ -276,7 +276,7 @@ describe('reducers/buc', () => {
     expect(
       bucReducer(initialBucState, {
         type: types.BUC_GET_BUCSLIST_SUCCESS,
-        payload: null
+        payload: { result: null }
       })
     ).toEqual({
       ...initialBucState,
@@ -300,7 +300,7 @@ describe('reducers/buc', () => {
         institutionNames: {}
       }, {
         type: types.BUC_GET_BUCSLIST_SUCCESS,
-        payload: [mockBuc]
+        payload: { result: [mockBuc] }
       })
     ).toEqual({
       ...initialBucState,

--- a/src/reducers/buc.test.ts
+++ b/src/reducers/buc.test.ts
@@ -50,7 +50,7 @@ describe('reducers/buc', () => {
         bucs: {}
       }, {
         type: types.BUC_CREATE_BUC_SUCCESS,
-        payload: { result: { caseId: '123', mockPayload: 'mockPayload' } },
+        payload: { caseId: '123', mockPayload: 'mockPayload' },
         context: {
           person: {
             aktoer: {

--- a/src/reducers/buc.ts
+++ b/src/reducers/buc.ts
@@ -162,7 +162,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.BUC_CREATE_BUC_SUCCESS: {
       const bucs = _.cloneDeep(state.bucs)
       const newSedsWithAttachments: SedsWithAttachmentsMap = _.cloneDeep(state.sedsWithAttachments)
-      const newBuc: ValidBuc = _.cloneDeep((action as ActionWithPayload).payload.result)
+      const newBuc: ValidBuc = _.cloneDeep((action as ActionWithPayload).payload)
 
       const person = (action as ActionWithPayload).context.person
       const avdod = (action as ActionWithPayload).context.avdod

--- a/src/reducers/buc.ts
+++ b/src/reducers/buc.ts
@@ -196,7 +196,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
         })
       }
 
-      bucs![(action as ActionWithPayload).payload.result.caseId] = newBuc
+      bucs![(action as ActionWithPayload).payload.caseId] = newBuc
 
       return {
         ...state,

--- a/src/reducers/buc.ts
+++ b/src/reducers/buc.ts
@@ -268,7 +268,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.BUC_CREATE_ATP_BUC_SUCCESS: {
       const bucs = _.cloneDeep(state.bucs)
       const newSedsWithAttachments: SedsWithAttachmentsMap = _.cloneDeep(state.sedsWithAttachments)
-      const newBuc: ValidBuc = _.cloneDeep((action as ActionWithPayload).payload.result)
+      const newBuc: ValidBuc = _.cloneDeep((action as ActionWithPayload).payload)
 
       // Cache seds allowing attachments
       if (newBuc.seds) {
@@ -277,7 +277,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
         })
       }
 
-      bucs![(action as ActionWithPayload).payload.result.caseId] = newBuc
+      bucs![(action as ActionWithPayload).payload.caseId] = newBuc
 
       return {
         ...state,

--- a/src/reducers/buc.ts
+++ b/src/reducers/buc.ts
@@ -159,7 +159,59 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
         rinaId: undefined
       }
 
-    case types.BUC_CREATE_BUC_SUCCESS:
+    case types.BUC_CREATE_BUC_SUCCESS: {
+      const bucs = _.cloneDeep(state.bucs)
+      const newSedsWithAttachments: SedsWithAttachmentsMap = _.cloneDeep(state.sedsWithAttachments)
+      const newBuc: ValidBuc = _.cloneDeep((action as ActionWithPayload).payload.result)
+
+      const person = (action as ActionWithPayload).context.person
+      const avdod = (action as ActionWithPayload).context.avdod
+      const avdodfnr = (action as ActionWithPayload).context.avdodfnr
+      const kravDato = (action as ActionWithPayload).context.kravDato
+
+      if (!newBuc.addedParams) {
+        newBuc.addedParams = {}
+      }
+
+      if (kravDato) {
+        newBuc.addedParams.kravDato = kravDato
+      }
+
+      if (bucsThatSupportAvdod(newBuc.type) && person) {
+        newBuc.addedParams.subject = {
+          gjenlevende: {
+            fnr: getFnr(person)
+          },
+          avdod: {
+            fnr: avdod ? avdod.fnr : avdodfnr
+          }
+        } as BUCSubject
+      }
+
+
+      // Cache seds allowing attachments
+      if (newBuc.seds) {
+        newBuc.seds.forEach((sed: Sed) => {
+          newSedsWithAttachments[sed.type] = sed.allowsAttachments
+        })
+      }
+
+      bucs![(action as ActionWithPayload).payload.result.caseId] = newBuc
+
+      return {
+        ...state,
+        currentBuc: newBuc.caseId,
+        sed: undefined,
+        countryList: undefined,
+        bucs,
+        kravDato: undefined,
+        newlyCreatedBuc: newBuc,
+        savingAttachmentsJob: undefined,
+        sedsWithAttachments: newSedsWithAttachments,
+        p6000s: undefined
+      }
+    }
+
     case types.GJENNY_CREATE_BUC_SUCCESS: {
       const bucs = _.cloneDeep(state.bucs)
       const newSedsWithAttachments: SedsWithAttachmentsMap = _.cloneDeep(state.sedsWithAttachments)
@@ -216,7 +268,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.BUC_CREATE_ATP_BUC_SUCCESS: {
       const bucs = _.cloneDeep(state.bucs)
       const newSedsWithAttachments: SedsWithAttachmentsMap = _.cloneDeep(state.sedsWithAttachments)
-      const newBuc: ValidBuc = _.cloneDeep((action as ActionWithPayload).payload)
+      const newBuc: ValidBuc = _.cloneDeep((action as ActionWithPayload).payload.result)
 
       // Cache seds allowing attachments
       if (newBuc.seds) {
@@ -225,7 +277,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
         })
       }
 
-      bucs![(action as ActionWithPayload).payload.caseId] = newBuc
+      bucs![(action as ActionWithPayload).payload.result.caseId] = newBuc
 
       return {
         ...state,
@@ -389,7 +441,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.BUC_GET_BUCSLIST_VEDTAK_SUCCESS: {
       // merge only the new ones, do not have duplicates
       const newBucsList = _.isNil(state.bucsList) ? [] : _.cloneDeep(state.bucsList);
-      (action as ActionWithPayload).payload?.forEach((buc: BucListItem) => {
+      (action as ActionWithPayload).payload.result?.forEach((buc: BucListItem) => {
         const foundIndex = _.findIndex(newBucsList, (b: BucListItem) => b.euxCaseId === buc.euxCaseId)
         if (foundIndex < 0) {
           newBucsList.push(buc)
@@ -419,12 +471,12 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
 
     case types.BUC_GET_BUC_SUCCESS: {
       const bucs = _.cloneDeep(state.bucs)
-      const buc: Buc | undefined = (action as ActionWithPayload).payload
+      const buc: Buc | undefined = (action as ActionWithPayload).payload.result
 
       if (!buc?.caseId || !buc?.type) {
-        if((action as ActionWithPayload).payload) {
+        if((action as ActionWithPayload).payload.result) {
           // CAN BE UNDEFINED ON LOCALHOST
-          bucs![(action as ActionWithPayload).context.rinaCaseId] = (action as ActionWithPayload).payload
+          bucs![(action as ActionWithPayload).context.rinaCaseId] = (action as ActionWithPayload).payload.result
         }
 
         return {
@@ -471,8 +523,8 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
           (buc as ValidBuc).addedParams.subject = _.cloneDeep(buc.subject)
         }
 
-        bucs![(action as ActionWithPayload).payload.caseId] = (action as ActionWithPayload).payload
-        bucs![(action as ActionWithPayload).payload.caseId].deltakere = bucs![(action as ActionWithPayload).payload.caseId].institusjon
+        bucs![(action as ActionWithPayload).payload.result.caseId] = (action as ActionWithPayload).payload.result
+        bucs![(action as ActionWithPayload).payload.result.caseId].deltakere = bucs![(action as ActionWithPayload).payload.result.caseId].institusjon
 
         return {
           ...state,
@@ -515,7 +567,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
 
       return {
         ...state,
-        bucOptions: _.difference((action as ActionWithPayload).payload, excludedBucs)
+        bucOptions: _.difference((action as ActionWithPayload).payload.result, excludedBucs)
       }
     }
 


### PR DESCRIPTION
## Summary

Aligns BUC controller endpoints with the `FrontendResponse` pattern already used by `PersonController` and `EuxController` (#388). The backend now wraps responses in `{ result: <data> }`.

## Changes

**Actions** — wrap `expectedPayload` in `{ result: ... }`:
- `src/actions/buc.ts`: `createBuc`, `createATPBuc`, `fetchBucsList`, `fetchBucsListWithAvdodFnr`, `fetchBucsListWithVedtakId`, `fetchBuc`, `getBucOptions`
- `src/actions/gjenny.ts`: `createBucGjenny` (shares reducer case with `BUC_CREATE_BUC_SUCCESS`)

**Reducers** — access `payload.result` instead of `payload`:
- `src/reducers/buc.ts`: `BUC_CREATE_BUC_SUCCESS`/`GJENNY_CREATE_BUC_SUCCESS`, `BUC_CREATE_ATP_BUC_SUCCESS`, `BUC_GET_BUCSLIST_SUCCESS`/`BUC_GET_BUCSLIST_VEDTAK_SUCCESS`, `BUC_GET_BUC_SUCCESS`, `BUC_GET_BUC_OPTIONS_SUCCESS`

**Tests** — updated payloads in `src/reducers/buc.test.ts`

### Not in scope
- `BUC_GET_KRAVDATO_URL` / `BUC_GET_SAKTYPE_URL` — use `PEN_URL`, different controller
- `GJENNY_GET_BUCSLIST_*` — use `GJENNY_URL`, separate controller

## Verification

- ✅ 444/444 tests pass
- ✅ TypeScript check clean
- ✅ Build succeeds

Closes #390