### PR TITLE
b - Fix infinite render loop in CountryDropdown when selecting Land

### DIFF
--- a/src/applications/P2000/Ektefelle/Ektefelle.tsx
+++ b/src/applications/P2000/Ektefelle/Ektefelle.tsx
@@ -16,11 +16,15 @@ import FoedestedFC from "../Foedested/Foedested";
 import Statsborgerskap from "../Statsborgerskap/Statsborgerskap";
 import {deletePSEDProp} from "src/actions/buc";
 import {Ektefelle as P2000Ektefelle} from "src/declarations/sed";
+import {createSelector} from "@reduxjs/toolkit";
 
 
-const mapState = (state: State): MainFormSelector => ({
-  validation: state.validation.status,
-})
+const mapState = createSelector(
+  (state: State) => state.validation.status,
+  (validation): MainFormSelector => ({
+    validation,
+  })
+)
 
 const Ektefelle: React.FC<MainFormProps> = ({
   label,
@@ -65,14 +69,17 @@ const Ektefelle: React.FC<MainFormProps> = ({
     }
   }
 
+  const isFoedestedEmpty = !!ektefelle?.person?.foedested && _.isEmpty(ektefelle.person.foedested)
+  const isPinEmpty = !!ektefelle?.person?.pin && _.isEmpty(ektefelle.person.pin)
+
   useEffect(() => {
-    if(ektefelle?.person?.foedested && _.isEmpty(ektefelle?.person?.foedested)){
+    if(isFoedestedEmpty){
       dispatch(deletePSEDProp(`${target}.person.foedested`))
     }
-    if(ektefelle?.person?.pin && _.isEmpty(ektefelle?.person?.pin)){
+    if(isPinEmpty){
       dispatch(deletePSEDProp(`${target}.person.pin`))
     }
-  }, [ektefelle])
+  }, [isFoedestedEmpty, isPinEmpty])
 
   return (
     <Box padding="space-16">

--- a/src/applications/P2000/Foedested/Foedested.tsx
+++ b/src/applications/P2000/Foedested/Foedested.tsx
@@ -11,10 +11,14 @@ import FlagPanel from "src/components/FlagPanel/FlagPanel";
 import CountryDropdown from "src/components/CountryDropdown/CountryDropdown";
 import FormTextBox from "src/components/Forms/FormTextBox";
 import {Person} from "src/declarations/sed";
+import {createSelector} from "@reduxjs/toolkit";
 
-const mapState = (state: State): MainFormSelector => ({
-  validation: state.validation.status
-})
+const mapState = createSelector(
+  (state: State) => state.validation.status,
+  (validation): MainFormSelector => ({
+    validation
+  })
+)
 
 export interface FoedestedProps {
   parentNamespace: string

--- a/src/applications/P2000/PersonOpplysninger/PersonOpplysninger.tsx
+++ b/src/applications/P2000/PersonOpplysninger/PersonOpplysninger.tsx
@@ -49,7 +49,7 @@ const PersonOpplysninger: React.FC<PersonOpplysningerProps> = ({
     <VStack gap="space-16">
       {parentEditMode &&
         <>
-          <HGrid gap="space-16" columns={3}>
+          <HGrid gap="space-16" columns={3} align="start">
             <Input
               error={v[namespace + '-etternavn']?.feilmelding}
               namespace={namespace}
@@ -93,7 +93,7 @@ const PersonOpplysninger: React.FC<PersonOpplysningerProps> = ({
       }
       {!parentEditMode &&
         <>
-          <HGrid gap="space-16" columns={3}>
+          <HGrid gap="space-16" columns={3} align="start">
             <FormTextBox padding="space-0"
               error={v[namespace + '-etternavn']?.feilmelding}
               id={namespace + '-etternavn'}

--- a/src/components/CountryDropdown/CountryDropdown.tsx
+++ b/src/components/CountryDropdown/CountryDropdown.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, {useMemo} from "react";
 import CountrySelect, {CountrySelectProps} from "@navikt/landvelger";
 import {State} from "src/declarations/reducers";
 import {useAppSelector} from "src/store";
 import {CountryCodeLists, CountryCodes, SimpleCountry} from "src/declarations/app";
 import {Bucs} from "src/declarations/buc";
+import {createSelector} from "@reduxjs/toolkit";
 
 export interface CountryDropdownSelector {
   currentBuc: string | undefined
@@ -11,11 +12,16 @@ export interface CountryDropdownSelector {
   countryCodes: CountryCodes | null | undefined
 }
 
-const mapState = (state: State): CountryDropdownSelector => ({
-  currentBuc: state.buc.currentBuc,
-  bucs: state.buc.bucs,
-  countryCodes: state.app.countryCodes
-})
+const mapState = createSelector(
+  (state: State) => state.buc.currentBuc,
+  (state: State) => state.buc.bucs,
+  (state: State) => state.app.countryCodes,
+  (currentBuc, bucs, countryCodes): CountryDropdownSelector => ({
+    currentBuc,
+    bucs,
+    countryCodes
+  })
+)
 
 export interface CountryDropdownProps extends CountrySelectProps<any>{
   dataTestId?: string
@@ -35,13 +41,17 @@ const CountryDropdown : React.FC<CountryDropdownProps> = ({
 
   const countryCodesByVersion: CountryCodeLists | undefined = countryCodes ? countryCodes[cdmVersion as keyof CountryCodes] : undefined
 
-  let includeList = countryCodeListName && countryCodesByVersion ? countryCodesByVersion[countryCodeListName as keyof CountryCodeLists] : rest.includeList
+  const includeList = useMemo(() => {
+    let list = countryCodeListName && countryCodesByVersion ? countryCodesByVersion[countryCodeListName as keyof CountryCodeLists] : rest.includeList
 
-  if(countryCodeListName && excludeNorway){
-    includeList = includeList?.filter((country: SimpleCountry) => country.landkode !== 'NO')
-  } else {!countryCodeListName && excludeNorway} {
-    includeList = includeList?.filter((it: string) => it !== 'NO')
-  }
+    if(countryCodeListName && excludeNorway){
+      list = list?.filter((country: SimpleCountry) => country.landkode !== 'NO')
+    } else if(!countryCodeListName && excludeNorway) {
+      list = list?.filter((it: string) => it !== 'NO')
+    }
+
+    return list
+  }, [countryCodeListName, countryCodesByVersion, excludeNorway, rest.includeList])
 
   return(
     <CountrySelect


### PR DESCRIPTION
## Problem

Some users experience a "Maximum update depth exceeded" React error when selecting a country (Land) in the Foedested (birth place) component on the Ektefelle tab. The error is intermittent — it depends on browser rendering timing.

## Root Cause

Three issues combined to create a feedback loop:

1. **CountryDropdown syntax bug** — A broken `else if` block caused `.filter()` to always execute, creating a new `includeList` array reference on every render. This made react-select see unstable `options` props, potentially triggering extra `onChange` events.

2. **Ektefelle useEffect with object dependency** — The `[ektefelle]` dependency fires on every Redux dispatch because the reducer always `_.cloneDeep(state.PSED)`, creating new object references even when data has not changed. This amplified the render loop when foedested/pin became empty objects.

3. **Unmemoized selectors** — Plain object selectors returned new `{}` on every call, causing unnecessary re-renders on every Redux dispatch.

## Fix

- **CountryDropdown**: Fix `else if` syntax and wrap `includeList` derivation in `useMemo` for stable references
- **Ektefelle**: Narrow `useEffect` dependency to `[isFoedestedEmpty, isPinEmpty]` (primitive booleans) — effect only fires when emptiness status actually changes
- **CountryDropdown, Ektefelle, Foedested**: Memoize selectors with `createSelector` from Redux Toolkit

## Verification

- TypeScript check passes (`tsc --noEmit`)
- All 444 tests pass
