### PR TITLE
R! - Handle FrontEndResponse wrapper from SedController endpoints

### DIFF
--- a/src/actions/buc.ts
+++ b/src/actions/buc.ts
@@ -362,7 +362,7 @@ export const getSed = (
   return call({
     url: sprintf(urls.SED_GET_SED_URL, { caseId, sedId: sed.id }),
     cascadeFailureError: true,
-    expectedPayload: mockP2000,
+    expectedPayload: { result: mockP2000, status: 'OK' },
     context: {
       sed: sed
     },
@@ -381,7 +381,7 @@ export const getSedP8000 = (
   return call({
     url: sprintf(urls.SED_GET_SED_URL, { caseId, sedId: sed.id }),
     cascadeFailureError: true,
-    expectedPayload: mockP8000,
+    expectedPayload: { result: mockP8000, status: 'OK' },
     context: {
       sed: sed
     },
@@ -488,7 +488,7 @@ export const getSedP4000 = (
   return call({
     url: sprintf(urls.SED_GET_SED_URL, { caseId, sedId: sed.id }),
     cascadeFailureError: true,
-    expectedPayload: mockP4000,
+    expectedPayload: { result: mockP4000, status: 'OK' },
     context: {
       sedId: sed.id
     },
@@ -506,7 +506,7 @@ export const getSedP6000 = (
   return call({
     url: sprintf(urls.SED_GET_P6000_URL, { rinaCaseId }),
     cascadeFailureError: true,
-    expectedPayload: mockP6000,
+    expectedPayload: { result: mockP6000, status: 'OK' },
     type: {
       request: types.SED_GET_P6000_REQUEST,
       success: types.SED_GET_P6000_SUCCESS,
@@ -521,7 +521,7 @@ export const getSedP6000PDF = (
   return call({
     url: sprintf(urls.SED_GET_PDF_URL, { rinaCaseId, documentId }),
     cascadeFailureError: true,
-    expectedPayload: mockPreviewPdf,
+    expectedPayload: { result: mockPreviewPdf, status: 'OK' },
     type: {
       request: types.SED_GET_P6000PDF_REQUEST,
       success: types.SED_GET_P6000PDF_SUCCESS,
@@ -538,7 +538,7 @@ export const getPreviewFile = (PSED: PSED): ActionWithPayload => {
   return call({
     method: 'POST',
     url: sprintf(urls.SED_PREVIEW_PDF_URL),
-    expectedPayload: mockPreviewPdf,
+    expectedPayload: { result: mockPreviewPdf, status: 'OK' },
     type: {
       request: types.SED_GET_PREVIEWPDF_REQUEST,
       success: types.SED_GET_PREVIEWPDF_SUCCESS,
@@ -554,7 +554,7 @@ export const getSedPreviewPDF = (
   return call({
     url: sprintf(urls.SED_GET_PDF_URL, { rinaCaseId, documentId }),
     cascadeFailureError: true,
-    expectedPayload: mockPreviewPdf,
+    expectedPayload: { result: mockPreviewPdf, status: 'OK' },
     type: {
       request: types.SED_GET_PREVIEWPDF_REQUEST,
       success: types.SED_GET_PREVIEWPDF_SUCCESS,
@@ -602,7 +602,7 @@ export const getSedList = (
   const url: string = sprintf(urls.SED_GET_SED_LIST_URL, { buc: buc.type, rinaId: buc.caseId })
   return call({
     url,
-    expectedPayload: mockSedList,
+    expectedPayload: { result: mockSedList, status: 'OK' },
     type: {
       request: types.SED_GET_SED_LIST_REQUEST,
       success: types.SED_GET_SED_LIST_SUCCESS,

--- a/src/actions/p5000.ts
+++ b/src/actions/p5000.ts
@@ -26,7 +26,7 @@ export const getSed = (
     cascadeFailureError: true,
     context: sed,
     //expectedPayload: mockP5000(sed, 'small'),
-    expectedPayload: mockSEDP5000_small,
+    expectedPayload: { result: mockSEDP5000_small, status: 'OK' },
     type: {
       request: types.SED_P5000_GET_REQUEST,
       success: types.SED_P5000_GET_SUCCESS,
@@ -47,7 +47,7 @@ export const sendP5000toRina = (
     method: 'PUT',
     body: payload,
     cascadeFailureError: true,
-    expectedPayload: { success: true },
+    expectedPayload: { result: { success: true }, status: 'OK' },
     context: {
       caseId,
       sedId,

--- a/src/reducers/buc.test.ts
+++ b/src/reducers/buc.test.ts
@@ -546,7 +546,7 @@ describe('reducers/buc', () => {
     expect(
       bucReducer(initialBucState, {
         type: types.SED_GET_SED_LIST_SUCCESS,
-        payload: ['P4000', 'A3012', 'B1000', 'P10000', 'X800', 'H208', 'H207', 'P2000']
+        payload: { result: ['P4000', 'A3012', 'B1000', 'P10000', 'X800', 'H208', 'H207', 'P2000'], status: 'OK' }
       })
     ).toEqual({
       ...initialBucState,

--- a/src/reducers/buc.ts
+++ b/src/reducers/buc.ts
@@ -702,7 +702,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
       const sedTypes = ['X', 'H', 'P']
       return {
         ...state,
-        sedList: (action as ActionWithPayload).payload.sort((a: string, b: string) => {
+        sedList: (action as ActionWithPayload).payload.result.sort((a: string, b: string) => {
           const mainCompare = parseInt(a.replace(/[^\d]/g, ''), 10) - parseInt(b.replace(/[^\d]/g, ''), 10)
           const sedTypeA = a.charAt(0)
           const sedTypeB = b.charAt(0)
@@ -759,7 +759,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
       return {
         ...state,
         p4000: {
-          ...(action as ActionWithPayload).payload,
+          ...(action as ActionWithPayload).payload.result,
           sedId: (action as ActionWithPayload).context.sedId
         }
       }
@@ -779,7 +779,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.SED_GET_P6000_SUCCESS:
       return {
         ...state,
-        p6000s: (action as ActionWithPayload).payload
+        p6000s: (action as ActionWithPayload).payload.result
       }
 
     case types.SED_P6000PDF_RESET:
@@ -798,7 +798,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.SED_GET_P6000PDF_SUCCESS:
       return {
         ...state,
-        p6000PDF: (action as ActionWithPayload).payload
+        p6000PDF: (action as ActionWithPayload).payload.result
       }
 
 
@@ -818,7 +818,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.SED_GET_PREVIEWPDF_SUCCESS:
       return {
         ...state,
-        previewPDF: (action as ActionWithPayload).payload
+        previewPDF: (action as ActionWithPayload).payload.result
       }
 
 
@@ -1006,7 +1006,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     }
 
     case types.SED_GET_SED_SUCCESS: {
-      const payload = (action as ActionWithPayload).payload
+      const payload = (action as ActionWithPayload).payload.result
       const sed = (action as ActionWithPayload).context.sed
       return {
         ...state,
@@ -1019,7 +1019,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     }
 
     case types.SED_GET_P8000SED_SUCCESS: {
-      const payload = (action as ActionWithPayload).payload
+      const payload = (action as ActionWithPayload).payload.result
       const sed = (action as ActionWithPayload).context.sed
 
       const fritekstArray: string[] | undefined = (payload as P8000SED).pensjon?.ytterligeinformasjon?.split(/\*+/)

--- a/src/reducers/p5000.test.ts
+++ b/src/reducers/p5000.test.ts
@@ -13,7 +13,7 @@ describe('reducers/p5000', () => {
         }
       }, {
         type: types.SED_P5000_GET_SUCCESS,
-        payload: mockSed2,
+        payload: { result: mockSed2, status: 'OK' },
         context: {
           id: 2
         }

--- a/src/reducers/p5000.ts
+++ b/src/reducers/p5000.ts
@@ -83,7 +83,7 @@ const p5000Reducer = (state: P5000State = initialP5000State, action: AnyAction):
       return {
         ...state,
         p5000sFromRinaMap: newP5000FromRinaMap,
-        sentP5000info: (action as ActionWithPayload).payload
+        sentP5000info: (action as ActionWithPayload).payload.result
       }
     }
 
@@ -139,7 +139,7 @@ const p5000Reducer = (state: P5000State = initialP5000State, action: AnyAction):
 
     case types.SED_P5000_GET_SUCCESS: {
       const newp5000FromRina = _.cloneDeep(state.p5000sFromRinaMap)
-      const payload = (action as ActionWithPayload).payload
+      const payload = (action as ActionWithPayload).payload.result
       const sedId = (action as ActionWithPayload).context.id
       fillWithKeys(payload, sedId)
       newp5000FromRina[sedId] = _.cloneDeep(payload)


### PR DESCRIPTION
Closes #433.

Backend companion: navikt/eessi-pensjon-fagmodul#541 / PR #542 (must deploy first).

## Changes

Reducers now read `.payload.result` for SedController-backed endpoints (mirrors BUC/EUX/PREFILL pattern):

- `src/reducers/buc.ts`: SED_GET_SED_LIST_SUCCESS, SED_GET_P4000_SUCCESS, SED_GET_P6000_SUCCESS, SED_GET_P6000PDF_SUCCESS, SED_GET_PREVIEWPDF_SUCCESS, SED_GET_SED_SUCCESS, SED_GET_P8000SED_SUCCESS
- `src/reducers/p5000.ts`: SED_P5000_SEND_SUCCESS, SED_P5000_GET_SUCCESS

SED_PUT_SED_SUCCESS doesn't read payload data — no change.

Actions wrap `expectedPayload` as `{ result, status: 'OK' }` so dev/mock mode mirrors prod:
- `src/actions/buc.ts`: getSed, getSedP8000, getSedP4000, getSedP6000, getSedP6000PDF, getPreviewFile, getSedPreviewPDF, getSedList
- `src/actions/p5000.ts`: getSed, sendP5000toRina

Tests updated to wrap SED success payloads accordingly.

## Verification

- `npm run typecheck` ✅
- `npm run test:filtered` ✅ (444 tests passed)

## Deploy order

**Backend first**, then frontend.