### PR TITLE
r - Refactor BeloepRows and InntektRows from Table to HGrid

### DIFF
--- a/src/applications/P2000/Beloep/BeloepRows.module.css
+++ b/src/applications/P2000/Beloep/BeloepRows.module.css
@@ -1,3 +1,21 @@
-.topAlignedCell {
-  vertical-align: top;
+.headerRow {
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+  padding-bottom: var(--ax-space-8);
+}
+
+.beloepRow {
+  padding: var(--ax-space-12) var(--ax-space-8);
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+}
+
+.beloepRow:nth-child(even) {
+  background-color: var(--ax-bg-neutral-softA);
+}
+
+.beloepRow:hover {
+  background-color: var(--ax-bg-neutral-moderate-hoverA);
+}
+
+.actionsCell {
+  white-space: nowrap;
 }

--- a/src/applications/P2000/Beloep/BeloepRows.module.css
+++ b/src/applications/P2000/Beloep/BeloepRows.module.css
@@ -1,6 +1,7 @@
 .headerRow {
   border-bottom: 1px solid var(--ax-border-neutral-subtle);
-  padding-bottom: var(--ax-space-8);
+  padding: var(--ax-space-8);
+  padding-top: 0;
 }
 
 .beloepRow {

--- a/src/applications/P2000/Beloep/BeloepRows.tsx
+++ b/src/applications/P2000/Beloep/BeloepRows.tsx
@@ -1,7 +1,7 @@
-import React, {Fragment, JSX, useState} from "react";
+import React, {JSX, useState} from "react";
 import {Beloep, Inntekt} from "src/declarations/p2000";
 import _ from "lodash";
-import {Select, Table} from "@navikt/ds-react";
+import {BodyLong, HGrid, Label, Select, VStack} from "@navikt/ds-react";
 import {getIdx} from "src/utils/namespace";
 import AddRemovePanel from "../../../components/AddRemovePanel/AddRemovePanel";
 import {resetValidation, setValidation} from "src/actions/validation";
@@ -24,6 +24,8 @@ import CurrencyDropdown from "src/components/CurrencyDropdown/CurrencyDropdown";
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status,
 })
+
+const beloepColumns = "minmax(0, 2fr) minmax(0, 3fr) minmax(0, 3fr) minmax(0, 3fr) minmax(0, 2fr) 15rem"
 
 export interface BeloepProps {
   beloep: Array<Beloep> | null | undefined
@@ -172,80 +174,55 @@ const BeloepRows: React.FC<BeloepProps> = ({
     const inEditMode = index < 0 || _editIndex === index
     const _beloep = index < 0 ? _newBeloep : (inEditMode ? _editBeloep : beloep)
 
-    return (
-      <Fragment key={_namespace
-      }>
-      {inEditMode && parentEditMode
-        ? (
-          <Table.Row>
-            <Table.DataCell
-              className={styles.topAlignedCell}
-              width={"10%"}
+    if (inEditMode && parentEditMode) {
+      return (
+        <div key={_namespace} className={styles.beloepRow}>
+          <HGrid columns={beloepColumns} gap="space-16" align="start">
+            <Input
+              error={_v[_namespace + '-beloep']?.feilmelding}
+              namespace={_namespace}
+              id='beloep-beloep'
+              label={t('p2000:form-ytelse-beloep-beloep')}
+              hideLabel={true}
+              onChanged={(e) => setBelop(e, index)}
+              value={replacePeriodsWithCommas(_beloep?.beloep ?? '')}
+            />
+            <CurrencyDropdown
+              error={_v[_namespace + '-valuta']?.feilmelding}
+              placeholder="Velg valuta"
+              id={_namespace + '-valuta'}
+              label={t('p2000:form-ytelse-beloep-valuta')}
+              hideLabel={true}
+              sort="noeuFirst"
+              onOptionSelected={(valuta: Currency) => setBeloepProperty("valuta", valuta.value, index)}
+              currencyCodeListName="verdensValuta"
+              values={_beloep?.valuta ?? ''}
+              includeHistoricCurrencies={true}
+            />
+            <DateField
+              id='gjeldendesiden'
+              label={t('p2000:form-ytelse-beloep-beloep-siden')}
+              hideLabel={true}
+              index={index}
+              error={_v[_namespace + '-gjeldendesiden']?.feilmelding}
+              namespace={_namespace}
+              onChanged={(e) => setBeloepProperty("gjeldendesiden", e!, index)}
+              dateValue={_beloep?.gjeldendesiden ?? ''}
+            />
+            <Select
+              error={_v[_namespace + '-betalingshyppighetytelse']?.feilmelding}
+              id='beloep-betalingshyppighetytelse'
+              label={t('p2000:form-ytelse-beloep-betalingshyppighet')}
+              hideLabel={true}
+              onChange={(e) => setBeloepProperty("betalingshyppighetytelse", e.target.value, index)}
+              value={_beloep?.betalingshyppighetytelse ?? ''}
             >
-              <Input
-                error={_v[_namespace + '-beloep']?.feilmelding}
-                namespace={_namespace}
-                id='beloep-beloep'
-                label={t('p2000:form-ytelse-beloep-beloep')}
-                hideLabel={true}
-                onChanged={(e) => setBelop(e, index)}
-                value={replacePeriodsWithCommas(_beloep?.beloep ?? '')}
-              />
-            </Table.DataCell>
-            <Table.DataCell
-              className={styles.topAlignedCell}
-              width={"10%"}
-            >
-              <CurrencyDropdown
-                error={_v[_namespace + '-valuta']?.feilmelding}
-                placeholder="Velg valuta"
-                id={_namespace + '-valuta'}
-                label={t('p2000:form-ytelse-beloep-valuta')}
-                hideLabel={true}
-                sort="noeuFirst"
-                onOptionSelected={(valuta: Currency) => setBeloepProperty("valuta", valuta.value, index)}
-                currencyCodeListName="verdensValuta"
-                values={_beloep?.valuta ?? ''}
-                includeHistoricCurrencies={true}
-              />
-            </Table.DataCell>
-            <Table.DataCell
-              className={styles.topAlignedCell}
-              width={"20%"}
-            >
-              <DateField
-                id='gjeldendesiden'
-                label={t('p2000:form-ytelse-beloep-beloep-siden')}
-                hideLabel={true}
-                index={index}
-                error={_v[_namespace + '-gjeldendesiden']?.feilmelding}
-                namespace={_namespace}
-                onChanged={(e) => setBeloepProperty("gjeldendesiden", e!, index)}
-                dateValue={_beloep?.gjeldendesiden ?? ''}
-              />
-            </Table.DataCell>
-            <Table.DataCell
-              className={styles.topAlignedCell}
-              width={"20%"}
-            >
-              <Select
-                error={_v[_namespace + '-betalingshyppighetytelse']?.feilmelding}
-                id='beloep-betalingshyppighetytelse'
-                label={t('p2000:form-ytelse-beloep-betalingshyppighet')}
-                hideLabel={true}
-                onChange={(e) => setBeloepProperty("betalingshyppighetytelse", e.target.value, index)}
-                value={_beloep?.betalingshyppighetytelse ?? ''}
-              >
-                <option value=''>Velg</option>
-                {betalingshyppighetOptions.map((option) => {
-                  return(<option key={option.value} value={option.value}>{option.label}</option>)
-                })}
-              </Select>
-            </Table.DataCell>
-            <Table.DataCell
-              className={styles.topAlignedCell}
-              width={"20%"}
-            >
+              <option value=''>Velg</option>
+              {betalingshyppighetOptions.map((option) => {
+                return(<option key={option.value} value={option.value}>{option.label}</option>)
+              })}
+            </Select>
+            <div>
               {_beloep?.betalingshyppighetytelse === "99" &&
                 <Input
                   error={_v[_namespace + '-annenbetalingshyppighetytelse']?.feilmelding}
@@ -257,11 +234,8 @@ const BeloepRows: React.FC<BeloepProps> = ({
                   value={_beloep?.annenbetalingshyppighetytelse ?? ''}
                 />
               }
-            </Table.DataCell>
-            <Table.DataCell
-              className={styles.topAlignedCell}
-              width={"20%"}
-            >
+            </div>
+            <div className={styles.actionsCell}>
               <AddRemovePanel<Inntekt>
                 item={beloep}
                 noMargin={true}
@@ -274,61 +248,68 @@ const BeloepRows: React.FC<BeloepProps> = ({
                 onConfirmEdit={onSaveEdit}
                 onCancelEdit={() => onCloseEdit(_namespace)}
               />
-            </Table.DataCell>
-          </Table.Row>
-        )
-        : (
-          <Table.Row>
-            <Table.DataCell width={"10%"}>
-              {replacePeriodsWithCommas(beloep?.beloep)}
-            </Table.DataCell>
-            <Table.DataCell width={"10%"}>
-              {beloep?.valuta}
-            </Table.DataCell>
-            <Table.DataCell width={"20%"}>
-              {formatDate(beloep?.gjeldendesiden as string)}
-            </Table.DataCell>
-            <Table.DataCell width={"40%"} colSpan={2}>
-              {beloep?.betalingshyppighetytelse ?
-                beloep?.betalingshyppighetytelse === "99" ?
-                  beloep?.annenbetalingshyppighetytelse :
-                  betalingshyppighetMap[beloep?.betalingshyppighetytelse]
-                : ''
-              }
-            </Table.DataCell>
-            <Table.DataCell width={"20%"}>
-              {parentEditMode &&
-                <AddRemovePanel<Inntekt>
-                  noMargin={true}
-                  item={beloep}
-                  index={index}
-                  inEditMode={inEditMode}
-                  onRemove={onRemove}
-                  onAddNew={onAddNew}
-                  onCancelNew={onCloseNew}
-                  onStartEdit={onStartEdit}
-                  onConfirmEdit={onSaveEdit}
-                  onCancelEdit={() => onCloseEdit(_namespace)}
-                  alwaysVisible={true}
-                />
-              }
-            </Table.DataCell>
-          </Table.Row>
-        )
-      }
-      </Fragment>
+            </div>
+          </HGrid>
+        </div>
+      )
+    }
+
+    return (
+      <div key={_namespace} className={styles.beloepRow}>
+        <HGrid columns={beloepColumns} gap="space-16" align="center">
+          <BodyLong>
+            {replacePeriodsWithCommas(beloep?.beloep)}
+          </BodyLong>
+          <BodyLong>
+            {beloep?.valuta}
+          </BodyLong>
+          <BodyLong>
+            {formatDate(beloep?.gjeldendesiden as string)}
+          </BodyLong>
+          <BodyLong style={{gridColumn: "span 2"}}>
+            {beloep?.betalingshyppighetytelse ?
+              beloep?.betalingshyppighetytelse === "99" ?
+                beloep?.annenbetalingshyppighetytelse :
+                betalingshyppighetMap[beloep?.betalingshyppighetytelse]
+              : ''
+            }
+          </BodyLong>
+          <div className={styles.actionsCell}>
+            {parentEditMode &&
+              <AddRemovePanel<Inntekt>
+                noMargin={true}
+                item={beloep}
+                index={index}
+                inEditMode={inEditMode}
+                onRemove={onRemove}
+                onAddNew={onAddNew}
+                onCancelNew={onCloseNew}
+                onStartEdit={onStartEdit}
+                onConfirmEdit={onSaveEdit}
+                onCancelEdit={() => onCloseEdit(_namespace)}
+                alwaysVisible={true}
+              />
+            }
+          </div>
+        </HGrid>
+      </div>
     )
   }
 
   return (
-    <>
+    <VStack>
+      <HGrid columns={beloepColumns} gap="space-16" className={styles.headerRow}>
+        <Label>Beløp</Label>
+        <Label>Valuta</Label>
+        <Label>Beløp siden</Label>
+        <Label style={{gridColumn: "span 2"}}>Betalingshyppighet</Label>
+        <div />
+      </HGrid>
       {_.isEmpty(beloep) && !newBeloepForm
         ? (
-          <Table.Row>
-            <Table.DataCell colSpan={6}>
-              <em>Ingen beløp</em>
-            </Table.DataCell>
-          </Table.Row>
+          <BodyLong>
+            <em>Ingen beløp</em>
+          </BodyLong>
         )
         : (
           <>
@@ -337,7 +318,7 @@ const BeloepRows: React.FC<BeloepProps> = ({
         )
       }
       {parentEditMode && newBeloepForm && renderRow(null, -1)}
-    </>
+    </VStack>
   )
 }
 

--- a/src/applications/P2000/Beloep/BeloepRows.tsx
+++ b/src/applications/P2000/Beloep/BeloepRows.tsx
@@ -298,13 +298,16 @@ const BeloepRows: React.FC<BeloepProps> = ({
 
   return (
     <VStack>
-      <HGrid columns={beloepColumns} gap="space-16" className={styles.headerRow}>
-        <Label>Beløp</Label>
-        <Label>Valuta</Label>
-        <Label>Beløp siden</Label>
-        <Label style={{gridColumn: "span 2"}}>Betalingshyppighet</Label>
-        <div />
-      </HGrid>
+      <div className={styles.headerRow}>
+        <HGrid columns={beloepColumns} gap="space-16">
+          <Label>Beløp</Label>
+          <Label>Valuta</Label>
+          <Label>Beløp siden</Label>
+          <Label>Betalingshyppighet</Label>
+          <div />
+          <div />
+        </HGrid>
+      </div>
       {_.isEmpty(beloep) && !newBeloepForm
         ? (
           <BodyLong>

--- a/src/applications/P2000/Inntekt/InntektRows.module.css
+++ b/src/applications/P2000/Inntekt/InntektRows.module.css
@@ -1,6 +1,7 @@
 .headerRow {
   border-bottom: 1px solid var(--ax-border-neutral-subtle);
-  padding-bottom: var(--ax-space-8);
+  padding: var(--ax-space-8);
+  padding-top: 0;
 }
 
 .inntektRow {

--- a/src/applications/P2000/Inntekt/InntektRows.module.css
+++ b/src/applications/P2000/Inntekt/InntektRows.module.css
@@ -1,3 +1,21 @@
-.topAlignedCell {
-  vertical-align: top;
+.headerRow {
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+  padding-bottom: var(--ax-space-8);
+}
+
+.inntektRow {
+  padding: var(--ax-space-12) var(--ax-space-8);
+  border-bottom: 1px solid var(--ax-border-neutral-subtle);
+}
+
+.inntektRow:nth-child(even) {
+  background-color: var(--ax-bg-neutral-softA);
+}
+
+.inntektRow:hover {
+  background-color: var(--ax-bg-neutral-moderate-hoverA);
+}
+
+.actionsCell {
+  white-space: nowrap;
 }

--- a/src/applications/P2000/Inntekt/InntektRows.tsx
+++ b/src/applications/P2000/Inntekt/InntektRows.tsx
@@ -1,7 +1,7 @@
-import React, {Fragment, JSX, useState} from "react";
+import React, {JSX, useState} from "react";
 import {Inntekt} from "src/declarations/p2000";
 import _ from "lodash";
-import {Select, Table} from "@navikt/ds-react";
+import {BodyLong, HGrid, Label, Select, VStack} from "@navikt/ds-react";
 import {getIdx} from "src/utils/namespace";
 import AddRemovePanel from "../../../components/AddRemovePanel/AddRemovePanel";
 import {resetValidation, setValidation} from "src/actions/validation";
@@ -24,6 +24,8 @@ import CurrencyDropdown from "src/components/CurrencyDropdown/CurrencyDropdown";
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status,
 })
+
+const inntektColumns = "minmax(0, 2fr) minmax(0, 3fr) minmax(0, 3fr) minmax(0, 3fr) 15rem"
 
 export interface InntektProps {
   inntekt: Array<Inntekt> | null | undefined
@@ -169,142 +171,126 @@ const InntektRows: React.FC<InntektProps> = ({
     const _v: Validation = index < 0 ? _validation : validation
     const inEditMode = index < 0 || _editIndex === index
     const _inntekt = index < 0 ? _newInntekt : (inEditMode ? _editInntekt : inntekt)
+
+    if (inEditMode && parentEditMode) {
+      return (
+        <div key={_namespace} className={styles.inntektRow}>
+          <HGrid columns={inntektColumns} gap="space-16" align="start">
+            <Input
+              error={_v[_namespace + '-beloep']?.feilmelding}
+              namespace={_namespace}
+              id='inntekt-beloep'
+              label={t('p2000:form-arbeidsforhold-inntekt-belop')}
+              hideLabel={true}
+              onChanged={(e) => setBelop(e, index)}
+              value={replacePeriodsWithCommas(_inntekt?.beloep ?? '')}
+            />
+            <CurrencyDropdown
+              error={_v[_namespace + '-valuta']?.feilmelding}
+              placeholder="Velg valuta"
+              id={_namespace + '-valuta'}
+              label={t('p2000:form-arbeidsforhold-inntekt-valuta')}
+              hideLabel={true}
+              sort="noeuFirst"
+              onOptionSelected={(valuta: Currency) => setInntektProperty("valuta", valuta.value, index)}
+              currencyCodeListName="verdensValuta"
+              values={_inntekt?.valuta ?? ''}
+              includeHistoricCurrencies={true}
+            />
+            <DateField
+              id='beloeputbetaltsiden'
+              label={t('p2000:form-arbeidsforhold-inntekt-belop-siden')}
+              hideLabel={true}
+              index={index}
+              error={_v[_namespace + '-beloeputbetaltsiden']?.feilmelding}
+              namespace={_namespace}
+              onChanged={(e) => setInntektProperty("beloeputbetaltsiden", e!, index)}
+              dateValue={_inntekt?.beloeputbetaltsiden ?? ''}
+            />
+            <Select
+              error={_v[_namespace + '-betalingshyppighetinntekt']?.feilmelding}
+              id='inntekt-betalingshyppighetinntekt'
+              label={t('p2000:form-arbeidsforhold-inntekt-betalingshyppighet')}
+              hideLabel={true}
+              onChange={(e) => setInntektProperty("betalingshyppighetinntekt", e.target.value, index)}
+              value={_inntekt?.betalingshyppighetinntekt ?? ''}
+            >
+              <option value=''>Velg</option>
+              {betalingshyppighetOptions.map((option) => {
+                return(<option key={option.value} value={option.value}>{option.label}</option>)
+              })}
+            </Select>
+            <div className={styles.actionsCell}>
+              <AddRemovePanel<Inntekt>
+                noMargin={true}
+                item={inntekt}
+                index={index}
+                inEditMode={inEditMode}
+                onRemove={onRemove}
+                onAddNew={onAddNew}
+                onCancelNew={onCloseNew}
+                onStartEdit={onStartEdit}
+                onConfirmEdit={onSaveEdit}
+                onCancelEdit={() => onCloseEdit(_namespace)}
+                alwaysVisible={true}
+              />
+            </div>
+          </HGrid>
+        </div>
+      )
+    }
+
     return (
-      <Fragment key={_namespace}>
-        {inEditMode && parentEditMode
-          ? (
-              <Table.Row>
-                <Table.DataCell
-                  className={styles.topAlignedCell}
-                  width={"10%"}
-                >
-                  <Input
-                    error={_v[_namespace + '-beloep']?.feilmelding}
-                    namespace={_namespace}
-                    id='inntekt-beloep'
-                    label={t('p2000:form-arbeidsforhold-inntekt-belop')}
-                    hideLabel={true}
-                    onChanged={(e) => setBelop(e, index)}
-                    value={replacePeriodsWithCommas(_inntekt?.beloep ?? '')}
-                  />
-                </Table.DataCell>
-                <Table.DataCell
-                  className={styles.topAlignedCell}
-                  width={"20%"}
-                >
-                  <CurrencyDropdown
-                    error={_v[_namespace + '-valuta']?.feilmelding}
-                    placeholder="Velg valuta"
-                    id={_namespace + '-valuta'}
-                    label={t('p2000:form-arbeidsforhold-inntekt-valuta')}
-                    hideLabel={true}
-                    sort="noeuFirst"
-                    onOptionSelected={(valuta: Currency) => setInntektProperty("valuta", valuta.value, index)}
-                    currencyCodeListName="verdensValuta"
-                    values={_inntekt?.valuta ?? ''}
-                    includeHistoricCurrencies={true}
-                  />
-                </Table.DataCell>
-                <Table.DataCell
-                  className={styles.topAlignedCell}
-                  width={"20%"}
-                >
-                  <DateField
-                    id='beloeputbetaltsiden'
-                    label={t('p2000:form-arbeidsforhold-inntekt-belop-siden')}
-                    hideLabel={true}
-                    index={index}
-                    error={_v[_namespace + '-beloeputbetaltsiden']?.feilmelding}
-                    namespace={_namespace}
-                    onChanged={(e) => setInntektProperty("beloeputbetaltsiden", e!, index)}
-                    dateValue={_inntekt?.beloeputbetaltsiden ?? ''}
-                  />
-                </Table.DataCell>
-                <Table.DataCell
-                  className={styles.topAlignedCell}
-                  width={"20%"}
-                >
-                  <Select
-                    error={_v[_namespace + '-betalingshyppighetinntekt']?.feilmelding}
-                    id='inntekt-betalingshyppighetinntekt'
-                    label={t('p2000:form-arbeidsforhold-inntekt-betalingshyppighet')}
-                    hideLabel={true}
-                    onChange={(e) => setInntektProperty("betalingshyppighetinntekt", e.target.value, index)}
-                    value={_inntekt?.betalingshyppighetinntekt ?? ''}
-                  >
-                    <option  value=''>Velg</option>
-                    {betalingshyppighetOptions.map((option) => {
-                      return(<option key={option.value} value={option.value}>{option.label}</option>)
-                    })}
-                  </Select>
-                </Table.DataCell>
-                <Table.DataCell
-                  className={styles.topAlignedCell}
-                  width={"20%"}
-                >
-                  <AddRemovePanel<Inntekt>
-                    noMargin={true}
-                    item={inntekt}
-                    index={index}
-                    inEditMode={inEditMode}
-                    onRemove={onRemove}
-                    onAddNew={onAddNew}
-                    onCancelNew={onCloseNew}
-                    onStartEdit={onStartEdit}
-                    onConfirmEdit={onSaveEdit}
-                    onCancelEdit={() => onCloseEdit(_namespace)}
-                    alwaysVisible={true}
-                  />
-                </Table.DataCell>
-              </Table.Row>
-            )
-          : (
-            <Table.Row>
-              <Table.DataCell width={"10%"}>
-                {replacePeriodsWithCommas(inntekt?.beloep)}
-              </Table.DataCell>
-              <Table.DataCell width={"10%"}>
-                {inntekt?.valuta}
-              </Table.DataCell>
-              <Table.DataCell width={"20%"}>
-                {formatDate(inntekt?.beloeputbetaltsiden as string)}
-              </Table.DataCell>
-              <Table.DataCell width={"40%"}>
-                {inntekt?.betalingshyppighetinntekt ? betalingshyppighetMap[inntekt?.betalingshyppighetinntekt] : ''}
-              </Table.DataCell>
-              <Table.DataCell width={"20%"}>
-                {parentEditMode &&
-                  <AddRemovePanel<Inntekt>
-                    noMargin={true}
-                    item={inntekt}
-                    index={index}
-                    inEditMode={inEditMode}
-                    onRemove={onRemove}
-                    onAddNew={onAddNew}
-                    onCancelNew={onCloseNew}
-                    onStartEdit={onStartEdit}
-                    onConfirmEdit={onSaveEdit}
-                    onCancelEdit={() => onCloseEdit(_namespace)}
-                    alwaysVisible={true}
-                  />
-                }
-              </Table.DataCell>
-            </Table.Row>
-          )
-        }
-      </Fragment>
+      <div key={_namespace} className={styles.inntektRow}>
+        <HGrid columns={inntektColumns} gap="space-16" align="center">
+          <BodyLong>
+            {replacePeriodsWithCommas(inntekt?.beloep)}
+          </BodyLong>
+          <BodyLong>
+            {inntekt?.valuta}
+          </BodyLong>
+          <BodyLong>
+            {formatDate(inntekt?.beloeputbetaltsiden as string)}
+          </BodyLong>
+          <BodyLong>
+            {inntekt?.betalingshyppighetinntekt ? betalingshyppighetMap[inntekt?.betalingshyppighetinntekt] : ''}
+          </BodyLong>
+          <div className={styles.actionsCell}>
+            {parentEditMode &&
+              <AddRemovePanel<Inntekt>
+                noMargin={true}
+                item={inntekt}
+                index={index}
+                inEditMode={inEditMode}
+                onRemove={onRemove}
+                onAddNew={onAddNew}
+                onCancelNew={onCloseNew}
+                onStartEdit={onStartEdit}
+                onConfirmEdit={onSaveEdit}
+                onCancelEdit={() => onCloseEdit(_namespace)}
+                alwaysVisible={true}
+              />
+            }
+          </div>
+        </HGrid>
+      </div>
     )
   }
 
   return (
-    <>
+    <VStack>
+      <HGrid columns={inntektColumns} gap="space-16" className={styles.headerRow}>
+        <Label>Beløp</Label>
+        <Label>Valuta</Label>
+        <Label>Beløp siden</Label>
+        <Label>Betalingshyppighet</Label>
+        <div />
+      </HGrid>
       {_.isEmpty(inntekt) && !newInntektForm
         ? (
-          <Table.Row>
-            <Table.DataCell colSpan={5}>
-              Ingen inntekter
-            </Table.DataCell>
-          </Table.Row>
+          <BodyLong>
+            <em>Ingen inntekter</em>
+          </BodyLong>
         )
         : (
           <>
@@ -313,7 +299,7 @@ const InntektRows: React.FC<InntektProps> = ({
         )
       }
       {parentEditMode && newInntektForm && renderRow(null, -1)}
-    </>
+    </VStack>
   )
 }
 

--- a/src/applications/P2000/Inntekt/InntektRows.tsx
+++ b/src/applications/P2000/Inntekt/InntektRows.tsx
@@ -279,13 +279,15 @@ const InntektRows: React.FC<InntektProps> = ({
 
   return (
     <VStack>
-      <HGrid columns={inntektColumns} gap="space-16" className={styles.headerRow}>
-        <Label>Beløp</Label>
-        <Label>Valuta</Label>
-        <Label>Beløp siden</Label>
-        <Label>Betalingshyppighet</Label>
-        <div />
-      </HGrid>
+      <div className={styles.headerRow}>
+        <HGrid columns={inntektColumns} gap="space-16">
+          <Label>Beløp</Label>
+          <Label>Valuta</Label>
+          <Label>Beløp siden</Label>
+          <Label>Betalingshyppighet</Label>
+          <div />
+        </HGrid>
+      </div>
       {_.isEmpty(inntekt) && !newInntektForm
         ? (
           <BodyLong>

--- a/src/applications/P2000/Yrkesaktivitet/Yrkesaktivitet.tsx
+++ b/src/applications/P2000/Yrkesaktivitet/Yrkesaktivitet.tsx
@@ -1,4 +1,4 @@
-import {BodyLong, Box, Button, Heading, HStack, Label, Select, Spacer, Table, VStack} from "@navikt/ds-react";
+import {BodyLong, Box, Button, Heading, HStack, Label, Select, Spacer, VStack} from "@navikt/ds-react";
 import React, {Fragment, JSX, useEffect, useState} from "react";
 import {MainFormProps, MainFormSelector} from "../MainForm";
 import _ from "lodash";
@@ -256,27 +256,14 @@ const Yrkesaktivitet: React.FC<MainFormProps> = ({
               </Box>
             </HStack>
 
-            <Table zebraStripes={true}>
-              <Table.Header>
-                <Table.Row>
-                  <Table.HeaderCell scope="col">Beløp</Table.HeaderCell>
-                  <Table.HeaderCell scope="col">Valuta</Table.HeaderCell>
-                  <Table.HeaderCell scope="col">Beløp siden</Table.HeaderCell>
-                  <Table.HeaderCell scope="col">Betalingshyppighet</Table.HeaderCell>
-                  <Table.HeaderCell scope="col"></Table.HeaderCell>
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {inEditMode
-                  ? (
-                    <InntektRows parentEditMode={true} newInntektForm={_newInntektForm} setNewInntektForm={_setNewInntektForm} setInntekt={setInntekt} parentIndex={index} inntekt={_arbeidsforhold?.inntekt} parentNamespace={_namespace}/>
-                  )
-                  : (
-                    <InntektRows parentEditMode={false} newInntektForm={false} setNewInntektForm={_setNewInntektForm} setInntekt={setInntekt} parentIndex={index} inntekt={_arbeidsforhold?.inntekt} parentNamespace={_namespace}/>
-                  )
-                }
-              </Table.Body>
-            </Table>
+            {inEditMode
+              ? (
+                <InntektRows parentEditMode={true} newInntektForm={_newInntektForm} setNewInntektForm={_setNewInntektForm} setInntekt={setInntekt} parentIndex={index} inntekt={_arbeidsforhold?.inntekt} parentNamespace={_namespace}/>
+              )
+              : (
+                <InntektRows parentEditMode={false} newInntektForm={false} setNewInntektForm={_setNewInntektForm} setInntekt={setInntekt} parentIndex={index} inntekt={_arbeidsforhold?.inntekt} parentNamespace={_namespace}/>
+              )
+            }
             {inEditMode && !_newInntektForm &&
               <Box>
                 <Button

--- a/src/applications/P2000/Ytelser/Ytelser.tsx
+++ b/src/applications/P2000/Ytelser/Ytelser.tsx
@@ -14,7 +14,6 @@ import {
   Radio, RadioGroup,
   Select,
   Spacer,
-  Table,
   Tag,
   VStack
 } from "@navikt/ds-react";
@@ -326,20 +325,7 @@ const Ytelser: React.FC<MainFormProps> = ({
                 />
                 <Spacer/>
               </HGrid>
-              <Table zebraStripes={true}>
-                <Table.Header>
-                  <Table.Row>
-                    <Table.HeaderCell scope="col">Beløp</Table.HeaderCell>
-                    <Table.HeaderCell scope="col">Valuta</Table.HeaderCell>
-                    <Table.HeaderCell scope="col">Beløp siden</Table.HeaderCell>
-                    <Table.HeaderCell scope="col" colSpan={2}>Betalingshyppighet</Table.HeaderCell>
-                    <Table.HeaderCell scope="col"></Table.HeaderCell>
-                  </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  <BeloepRows beloep={_ytelse?.beloep} setBeloep={setBeloep} parentIndex={index} parentEditMode={true} newBeloepForm={_newBeloepForm} setNewBeloepForm={_setNewBeloepForm} parentNamespace={_namespace}/>
-                </Table.Body>
-              </Table>
+              <BeloepRows beloep={_ytelse?.beloep} setBeloep={setBeloep} parentIndex={index} parentEditMode={true} newBeloepForm={_newBeloepForm} setNewBeloepForm={_setNewBeloepForm} parentNamespace={_namespace}/>
               {inEditMode && !_newBeloepForm &&
                 <Box>
                   <Button
@@ -439,20 +425,7 @@ const Ytelser: React.FC<MainFormProps> = ({
                 <Spacer/>
               </HGrid>
 
-              <Table zebraStripes={true}>
-                <Table.Header>
-                  <Table.Row>
-                    <Table.HeaderCell scope="col">Beløp</Table.HeaderCell>
-                    <Table.HeaderCell scope="col">Valuta</Table.HeaderCell>
-                    <Table.HeaderCell scope="col">Beløp siden</Table.HeaderCell>
-                    <Table.HeaderCell scope="col" colSpan={2}>Betalingshyppighet</Table.HeaderCell>
-                    <Table.HeaderCell scope="col"></Table.HeaderCell>
-                  </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                  <BeloepRows parentEditMode={false} newBeloepForm={false} setNewBeloepForm={_setNewBeloepForm} setBeloep={setBeloep} parentIndex={index} beloep={_ytelse?.beloep} parentNamespace={_namespace}/>
-                </Table.Body>
-              </Table>
+              <BeloepRows parentEditMode={false} newBeloepForm={false} setNewBeloepForm={_setNewBeloepForm} setBeloep={setBeloep} parentIndex={index} beloep={_ytelse?.beloep} parentNamespace={_namespace}/>
               {_ytelse?.mottasbasertpaa &&
                 <VStack>
                   <Label>{t('p2000:form-ytelse-mottas-basert-paa')}</Label>


### PR DESCRIPTION
## Summary

Replaces `Table.Row`/`Table.DataCell` with `HGrid` layout in both `BeloepRows` and `InntektRows` components.

### Changes
- **BeloepRows** and **InntektRows** now use `HGrid` with consistent column templates
- Headers rendered once via `Label` elements inside each component
- Rows have zebra striping (`nth-child(even)`), hover effect, and border lines using Aksel `--ax-` tokens
- `AddRemovePanel` actions column has a fixed `15rem` width with `white-space: nowrap` to prevent wrapping
- Parent components (`Ytelser`, `Yrkesaktivitet`) no longer wrap in `<Table>`
- Removed unused `Table` imports