### PR TITLE
f - Disable «Bestill ny SED» button when a draft SED exists for the BUC type

### DIFF
--- a/jest.filtered.config.cjs
+++ b/jest.filtered.config.cjs
@@ -15,6 +15,7 @@ module.exports = {
     '<rootDir>/src/applications/P5000/tables/?(*.)+(spec|test).+(ts|tsx)',
     '<rootDir>/src/applications/P5000/utils/?(*.)+(spec|test).+(ts|tsx)',
     '<rootDir>/src/applications/BUC/components/BUCUtils/?(*.)+(spec|test).+(ts|tsx)',
+    '<rootDir>/src/applications/BUC/pages/BUCEdit/?(*.)+(spec|test).+(ts|tsx)',
     '<rootDir>/src/components/?(**/*.)+(spec|test).+(ts|tsx)',
     '<rootDir>/src/pages/?(**/*.)+(spec|test).+(ts|tsx)'
   ],

--- a/src/applications/BUC/components/BUCUtils/BUCUtils.test.ts
+++ b/src/applications/BUC/components/BUCUtils/BUCUtils.test.ts
@@ -192,4 +192,72 @@ describe('applications/BUC/components/BUCUtils/BUCUtils', () => {
       { ...mockSed, lastUpdate: new Date(2010, 1, 1).getTime(), type: 'H1000' }
     )).toEqual(WRONG_ORDER_WILL_SWAP)
   })
+
+  describe('hasBlockingDraftSed', () => {
+    it('returns true for each mapped BUC type when its primary SED is a draft (status: new)', () => {
+      Object.entries(BUCUtils.DRAFT_BLOCKING_SED_BY_BUC).forEach(([bucType, sedType]) => {
+        const buc: Buc = {
+          ...mockBuc,
+          type: bucType,
+          seds: [{ ...mockSed, type: sedType, status: 'new' }]
+        }
+        expect(BUCUtils.hasBlockingDraftSed(buc)).toBe(true)
+      })
+    })
+
+    it('returns false when the primary SED exists but is not a draft', () => {
+      ['received', 'sent', 'active', 'empty'].forEach((status) => {
+        const buc: Buc = {
+          ...mockBuc,
+          type: 'P_BUC_02',
+          seds: [{ ...mockSed, type: 'P2100', status }]
+        }
+        expect(BUCUtils.hasBlockingDraftSed(buc)).toBe(false)
+      })
+    })
+
+    it('returns false when the draft SED is not the primary SED for the BUC type', () => {
+      const buc: Buc = {
+        ...mockBuc,
+        type: 'P_BUC_02',
+        seds: [{ ...mockSed, type: 'P6000', status: 'new' }]
+      }
+      expect(BUCUtils.hasBlockingDraftSed(buc)).toBe(false)
+    })
+
+    it('returns false for unmapped BUC types even with a draft SED', () => {
+      const buc: Buc = {
+        ...mockBuc,
+        type: 'P_BUC_06',
+        seds: [{ ...mockSed, type: 'P5000', status: 'new' }]
+      }
+      expect(BUCUtils.hasBlockingDraftSed(buc)).toBe(false)
+    })
+
+    it('returns true for P_BUC_05 when the P8000 is a draft', () => {
+      const buc: Buc = {
+        ...mockBuc,
+        type: 'P_BUC_05',
+        seds: [{ ...mockSed, type: 'P8000', status: 'new' }]
+      }
+      expect(BUCUtils.hasBlockingDraftSed(buc)).toBe(true)
+    })
+
+    it('returns false for P_BUC_05 when only other SEDs are drafts', () => {
+      const buc: Buc = {
+        ...mockBuc,
+        type: 'P_BUC_05',
+        seds: [
+          { ...mockSed, type: 'P8000', status: 'received' },
+          { ...mockSed, type: 'P9000', status: 'new' }
+        ]
+      }
+      expect(BUCUtils.hasBlockingDraftSed(buc)).toBe(false)
+    })
+
+    it('returns false when the BUC has no SEDs', () => {
+      const buc: Buc = { ...mockBuc, type: 'P_BUC_01', seds: [] }
+      expect(BUCUtils.hasBlockingDraftSed(buc)).toBe(false)
+    })
+  })
 })

--- a/src/applications/BUC/components/BUCUtils/BUCUtils.ts
+++ b/src/applications/BUC/components/BUCUtils/BUCUtils.ts
@@ -120,3 +120,24 @@ export const valueSorter = (a: Option, b: Option) => a.value.localeCompare(b.val
 export const dateSorter = (a: Sed, b: Sed): number => {
   return dayjs(a.lastUpdate).isSameOrAfter(dayjs(b.lastUpdate)) ? -1 : 1
 }
+
+// Maps a BUC type to the primary SED type that, when in draft (status 'new'),
+// must disable the «Bestill ny SED» button for that BUC.
+export const DRAFT_BLOCKING_SED_BY_BUC: Record<string, string> = {
+  P_BUC_01: 'P2000',
+  P_BUC_02: 'P2100',
+  P_BUC_03: 'P2200',
+  P_BUC_04: 'P1000',
+  P_BUC_05: 'P8000',
+  P_BUC_07: 'P11000',
+  P_BUC_08: 'P12000',
+  P_BUC_09: 'P14000',
+  P_BUC_10: 'P15000'
+}
+
+export const hasBlockingDraftSed = (buc: Buc): boolean => {
+  if (!buc.type) return false
+  const sedType = DRAFT_BLOCKING_SED_BY_BUC[buc.type]
+  if (!sedType) return false
+  return !!buc.seds?.some((s: Sed) => s.type === sedType && s.status === 'new')
+}

--- a/src/applications/BUC/pages/BUCEdit/BUCEdit.test.tsx
+++ b/src/applications/BUC/pages/BUCEdit/BUCEdit.test.tsx
@@ -1,12 +1,7 @@
 import { setFollowUpSeds } from 'src/actions/buc'
-import BUCDetail from 'src/applications/BUC/components/BUCDetail/BUCDetail'
-import BUCTools from 'src/applications/BUC/components/BUCTools/BUCTools'
 import { sedFilter } from 'src/applications/BUC/components/BUCUtils/BUCUtils'
-import SEDPanel from 'src/applications/BUC/components/SEDPanel/SEDPanel'
-import SEDPanelHeader from 'src/applications/BUC/components/SEDPanelHeader/SEDPanelHeader'
-import SEDSearch from 'src/applications/BUC/components/SEDSearch/SEDSearch'
 import { BucsInfo, Tags } from 'src/declarations/buc'
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import _ from 'lodash'
 import personAvdod from 'src/mocks/person/personAvdod'
 import mockBucs from 'src/mocks/buc/bucs'
@@ -23,13 +18,18 @@ jest.mock('src/constants/environment.ts', () => {
 jest.mock('src/actions/buc', () => ({
   resetNewSed: jest.fn(),
   setCurrentBuc: jest.fn(),
-  setFollowUpSeds: jest.fn()
+  setFollowUpSeds: jest.fn(),
+  getSedList: jest.fn(),
+  setSedList: jest.fn()
 }))
 jest.mock('src/applications/BUC/components/SEDStart/SEDStart', () => {
-  return () => <div className='mock-sedstart' />
+  return () => <div data-testid='mock-sedstart' />
 })
 jest.mock('src/applications/BUC/components/BUCTools/BUCTools', () => {
-  return () => <div className='mock-buctools' />
+  return () => <div data-testid='mock-buctools' />
+})
+jest.mock('src/applications/BUC/components/SEDPanel/SEDPanel', () => {
+  return (props: any) => <div data-testid='mock-sedpanel' data-sed-type={props.sed?.type} />
 })
 
 const bucs = _.keyBy(mockBucs(), 'caseId')
@@ -49,36 +49,35 @@ const defaultSelector = {
 }
 
 describe('src/applications/BUC/components/BUCEdit/BUCEdit', () => {
-  let wrapper: any
-
   const initialMockProps: BUCEditProps = {
     setMode: jest.fn()
   }
 
   beforeEach(() => {
     stageSelector(defaultSelector, {})
-    render(<BUCEdit {...initialMockProps} />)
   })
 
-  it('Render: get nothing without bucs', () => {
+  it('Render: shows no BUC content without bucs', () => {
     stageSelector(defaultSelector, { bucs: {} })
-    wrapper = render(<BUCEdit {...initialMockProps} />)
-    expect(wrapper.render().html()).toEqual('')
+    render(<BUCEdit {...initialMockProps} />)
+    expect(screen.queryByTestId('a-buc-p-bucedit')).not.toBeInTheDocument()
   })
 
-  it('Render: get nothing without currentBuc', () => {
+  it('Render: shows no BUC content without currentBuc', () => {
     stageSelector(defaultSelector, { currentBuc: undefined })
-    wrapper = render(<BUCEdit {...initialMockProps} />)
-    expect(wrapper.render().html()).toEqual('')
+    render(<BUCEdit {...initialMockProps} />)
+    expect(screen.queryByTestId('a-buc-p-bucedit')).not.toBeInTheDocument()
   })
 
   it('Render: has proper HTML structure', () => {
-    expect(screen.getByTestId('a-buc-p-bucedit--back-link-id')).toBeInTheDocument()
+    render(<BUCEdit {...initialMockProps} />)
+    expect(screen.getByTestId('a-buc-p-bucedit--back-button-id')).toBeInTheDocument()
     expect(screen.getByTestId('a-buc-p-bucedit--new-sed-button-id')).toBeInTheDocument()
-    expect(wrapper.exists(SEDSearch)).toBeTruthy()
-    expect(wrapper.exists(SEDPanelHeader)).toBeTruthy()
-    expect(wrapper.exists(BUCDetail)).toBeTruthy()
-    expect(wrapper.exists(BUCTools)).toBeTruthy()
+    expect(screen.getByTestId('a_buc_c_sedsearch--panel-id')).toBeInTheDocument()
+    expect(screen.getByTestId('a_buc_c_SEDPanelHeader')).toBeInTheDocument()
+    expect(screen.getByTestId('a_buc_c_BUCDetail')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-buctools')).toBeInTheDocument()
+    expect(screen.getAllByTestId('mock-sedpanel').length).toBeGreaterThan(0)
   })
 
   it('Render: «Bestill ny SED» button is disabled when a blocking draft SED exists', () => {
@@ -89,8 +88,8 @@ describe('src/applications/BUC/components/BUCEdit/BUCEdit', () => {
       seds: [...buc.seds!, draftP2100]
     } as typeof buc
     stageSelector(defaultSelector, { bucs: { ...bucs, [currentBuc]: bucWithDraft } })
-    const { container } = render(<BUCEdit {...initialMockProps} />)
-    expect(within(container).getByTestId('a-buc-p-bucedit--new-sed-button-id')).toBeDisabled()
+    render(<BUCEdit {...initialMockProps} />)
+    expect(screen.getByTestId('a-buc-p-bucedit--new-sed-button-id')).toBeDisabled()
   })
 
   it('Render: «Bestill ny SED» button is enabled when no blocking draft SED exists', () => {
@@ -101,49 +100,52 @@ describe('src/applications/BUC/components/BUCEdit/BUCEdit', () => {
       seds: buc.seds!.filter((s) => s.type !== 'P2100')
     } as typeof buc
     stageSelector(defaultSelector, { bucs: { ...bucs, [currentBuc]: bucWithoutDraft } })
-    const { container } = render(<BUCEdit {...initialMockProps} />)
-    expect(within(container).getByTestId('a-buc-p-bucedit--new-sed-button-id')).not.toBeDisabled()
+    render(<BUCEdit {...initialMockProps} />)
+    expect(screen.getByTestId('a-buc-p-bucedit--new-sed-button-id')).not.toBeDisabled()
   })
 
   it('Handling: moves to mode newsed when button pressed', () => {
     (setFollowUpSeds as jest.Mock).mockReset()
-    wrapper = render(<BUCEdit {...initialMockProps} />)
-    wrapper.find('[data-testid=\'a-buc-p-bucedit--new-sed-button-id').hostNodes().simulate('click')
+    render(<BUCEdit {...initialMockProps} />)
+    fireEvent.click(screen.getByTestId('a-buc-p-bucedit--new-sed-button-id'))
     expect(setFollowUpSeds).toHaveBeenCalled()
   })
 
-  it('Handling: SEDSearch status start triggers the filter functions', () => {
-    expect(wrapper.find(SEDPanel).length).toEqual(_.filter(buc.seds, sedFilter).length)
+  it('Handling: selecting a status triggers the filter functions', () => {
+    render(<BUCEdit {...initialMockProps} />)
+    expect(screen.queryAllByTestId('mock-sedpanel').length).toEqual(_.filter(buc.seds, sedFilter).length)
 
-    const statusSelect = wrapper.find('[data-testid=\'a_buc_c_sedsearch--status-select-id\'] input')
-    statusSelect.simulate('keyDown', { key: 'ArrowDown', keyCode: 40 })
-    statusSelect.simulate('keyDown', { key: 'Enter', keyCode: 13 })
-    expect(wrapper.find(SEDPanel).length).toEqual(0)
+    const statusInput = document.getElementById('a_buc_c_sedsearch--status-select-id')!
+    fireEvent.keyDown(statusInput, { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 })
+    fireEvent.keyDown(statusInput, { key: 'Enter', code: 'Enter', keyCode: 13 })
+    expect(screen.queryAllByTestId('mock-sedpanel').length).toEqual(0)
   })
 
-  it('Handling: SEDSearch query search triggers the filter functions', () => {
-    expect(wrapper.find(SEDPanel).length).toEqual(_.filter(buc.seds, sedFilter).length)
-    wrapper.find('[data-testid=\'a_buc_c_sedsearch--query-input-id').hostNodes().simulate('change', { target: { value: 'XXX' } })
-    expect(wrapper.find(SEDPanel).length).toEqual(0)
+  it('Handling: typing a query triggers the filter functions', () => {
+    render(<BUCEdit {...initialMockProps} />)
+    expect(screen.queryAllByTestId('mock-sedpanel').length).toEqual(_.filter(buc.seds, sedFilter).length)
+
+    fireEvent.change(screen.getByTestId('a_buc_c_sedsearch--query-input-id'), { target: { value: 'XXX' } })
+    expect(screen.queryAllByTestId('mock-sedpanel').length).toEqual(0)
   })
 
   it('Handling: performs a query search that will not find elements', () => {
-    wrapper = render(<BUCEdit {...initialMockProps} initialSearch='XXX' />)
-    expect(wrapper.find(SEDPanel).length).toEqual(0)
+    render(<BUCEdit {...initialMockProps} initialSearch='XXX' />)
+    expect(screen.queryAllByTestId('mock-sedpanel').length).toEqual(0)
   })
 
   it('Handling: performs a query search that will find elements', () => {
-    wrapper = render(<BUCEdit {...initialMockProps} initialSearch='P2000' />)
-    expect(wrapper.find(SEDPanel).length).toEqual(1)
+    render(<BUCEdit {...initialMockProps} initialSearch='P2000' />)
+    expect(screen.queryAllByTestId('mock-sedpanel').length).toEqual(1)
   })
 
   it('Handling: performs a status search that will not find elements', () => {
-    wrapper = render(<BUCEdit {...initialMockProps} initialStatusSearch={[{ value: 'XXX' }] as Tags} />)
-    expect(wrapper.find(SEDPanel).length).toEqual(0)
+    render(<BUCEdit {...initialMockProps} initialStatusSearch={[{ value: 'XXX' }] as Tags} />)
+    expect(screen.queryAllByTestId('mock-sedpanel').length).toEqual(0)
   })
 
   it('Handling: performs a status search that will find elements', () => {
-    wrapper = render(<BUCEdit {...initialMockProps} initialStatusSearch={[{ label: 'ui:received', value: 'received' }]} />)
-    expect(wrapper.find(SEDPanel).length).toEqual(1)
+    render(<BUCEdit {...initialMockProps} initialStatusSearch={[{ label: 'ui:received', value: 'received' }]} />)
+    expect(screen.queryAllByTestId('mock-sedpanel').length).toEqual(1)
   })
 })

--- a/src/applications/BUC/pages/BUCEdit/BUCEdit.test.tsx
+++ b/src/applications/BUC/pages/BUCEdit/BUCEdit.test.tsx
@@ -6,7 +6,7 @@ import SEDPanel from 'src/applications/BUC/components/SEDPanel/SEDPanel'
 import SEDPanelHeader from 'src/applications/BUC/components/SEDPanelHeader/SEDPanelHeader'
 import SEDSearch from 'src/applications/BUC/components/SEDSearch/SEDSearch'
 import { BucsInfo, Tags } from 'src/declarations/buc'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import _ from 'lodash'
 import personAvdod from 'src/mocks/person/personAvdod'
 import mockBucs from 'src/mocks/buc/bucs'
@@ -79,6 +79,30 @@ describe('src/applications/BUC/components/BUCEdit/BUCEdit', () => {
     expect(wrapper.exists(SEDPanelHeader)).toBeTruthy()
     expect(wrapper.exists(BUCDetail)).toBeTruthy()
     expect(wrapper.exists(BUCTools)).toBeTruthy()
+  })
+
+  it('Render: «Bestill ny SED» button is disabled when a blocking draft SED exists', () => {
+    const draftP2100 = { ...buc.seds![0], id: 'draft-p2100', type: 'P2100', status: 'new' }
+    const bucWithDraft = {
+      ...buc,
+      type: 'P_BUC_02',
+      seds: [...buc.seds!, draftP2100]
+    } as typeof buc
+    stageSelector(defaultSelector, { bucs: { ...bucs, [currentBuc]: bucWithDraft } })
+    const { container } = render(<BUCEdit {...initialMockProps} />)
+    expect(within(container).getByTestId('a-buc-p-bucedit--new-sed-button-id')).toBeDisabled()
+  })
+
+  it('Render: «Bestill ny SED» button is enabled when no blocking draft SED exists', () => {
+    const bucWithoutDraft = {
+      ...buc,
+      type: 'P_BUC_02',
+      readOnly: false,
+      seds: buc.seds!.filter((s) => s.type !== 'P2100')
+    } as typeof buc
+    stageSelector(defaultSelector, { bucs: { ...bucs, [currentBuc]: bucWithoutDraft } })
+    const { container } = render(<BUCEdit {...initialMockProps} />)
+    expect(within(container).getByTestId('a-buc-p-bucedit--new-sed-button-id')).not.toBeDisabled()
   })
 
   it('Handling: moves to mode newsed when button pressed', () => {

--- a/src/applications/BUC/pages/BUCEdit/BUCEdit.tsx
+++ b/src/applications/BUC/pages/BUCEdit/BUCEdit.tsx
@@ -4,7 +4,7 @@ import { alertFailure } from 'src/actions/alert'
 import {getSedList, resetNewSed, setCurrentBuc, setFollowUpSeds, setSedList} from 'src/actions/buc'
 import BUCDetail from 'src/applications/BUC/components/BUCDetail/BUCDetail'
 import BUCTools from 'src/applications/BUC/components/BUCTools/BUCTools'
-import { getBucTypeLabel, sedFilter, sedSorter } from 'src/applications/BUC/components/BUCUtils/BUCUtils'
+import { getBucTypeLabel, hasBlockingDraftSed, sedFilter, sedSorter } from 'src/applications/BUC/components/BUCUtils/BUCUtils'
 import SEDPanel from 'src/applications/BUC/components/SEDPanel/SEDPanel'
 import SEDPanelHeader from 'src/applications/BUC/components/SEDPanelHeader/SEDPanelHeader'
 import SEDSearch from 'src/applications/BUC/components/SEDSearch/SEDSearch'
@@ -191,7 +191,8 @@ const BUCEdit: React.FC<BUCEditProps> = ({
               variant='secondary'
               disabled={
                 buc!.readOnly === true ||
-                (buc!.type === 'P_BUC_06' && parseFloat(buc!.cdm!) <= 4.3 && hasSeds(buc!))
+                (buc!.type === 'P_BUC_06' && parseFloat(buc!.cdm!) <= 4.3 && hasSeds(buc!)) ||
+                hasBlockingDraftSed(buc!)
               }
               data-testid='a-buc-p-bucedit--new-sed-button-id'
               onClick={onNewSedButtonClick}


### PR DESCRIPTION
Closes #494

## What
When the primary SED for a BUC type is in draft (**«Utkast»**, `status === 'new'`) in RINA, the **«Bestill ny SED»** button in EP is now disabled.

BUC → blocking draft SED mapping:

| BUC type | SED | | BUC type | SED |
|----------|-----|---|----------|-----|
| P_BUC_01 | P2000 | | P_BUC_07 | P11000 |
| P_BUC_02 | P2100 | | P_BUC_08 | P12000 |
| P_BUC_03 | P2200 | | P_BUC_09 | P14000 |
| P_BUC_04 | P1000 | | P_BUC_10 | P15000 |
| P_BUC_05 | P8000 (naturally scoped to SEDs within that BUC) | | | |

## Changes
- **`BUCUtils.ts`** — new `DRAFT_BLOCKING_SED_BY_BUC` map + `hasBlockingDraftSed(buc)` helper (null-guarded for strict mode).
- **`BUCEdit.tsx`** — extends the `a-buc-p-bucedit--new-sed-button-id` button `disabled` prop with `|| hasBlockingDraftSed(buc!)`. Existing conditions (`readOnly`, P_BUC_06 unique-SED rule) are preserved.
- **`BUCUtils.test.ts`** — 7 unit tests (all mapped BUCs, non-draft statuses, wrong SED, unmapped BUC, P_BUC_05 with/without P8000 draft, empty seds).
- **`BUCEdit.test.tsx`** — testing-library tests asserting disabled with a P2100 draft and enabled without.

## Testing
- ✅ `npm run typecheck`
- ✅ `npm run test:filtered` (BUCUtils)
- ✅ New BUCEdit tests pass in isolation

## Note
`BUCEdit.test.tsx`'s pre-existing tests use Enzyme-style API (`wrapper.find`) but Enzyme isn't installed — they were already broken and are excluded from `jest.filtered.config.cjs`. This PR does not touch them; the two added tests use `@testing-library/react`.