### PR TITLE
R! - Handle FrontendResponse wrapper from PensjonController endpoints

### DIFF
--- a/src/actions/buc.ts
+++ b/src/actions/buc.ts
@@ -260,7 +260,7 @@ export const fetchKravDato = ({
 }: any): ActionWithPayload<any> => {
   return call({
     url: sprintf(urls.BUC_GET_KRAVDATO_URL, { sakId, kravId, aktoerId }),
-    expectedPayload: mockKravDato,
+    expectedPayload: { result: mockKravDato, status: 'OK' },
     type: {
       request: types.BUC_GET_KRAVDATO_REQUEST,
       success: types.BUC_GET_KRAVDATO_SUCCESS,
@@ -587,7 +587,7 @@ export const getSakType = (
 ): ActionWithPayload<any> => {
   return call({
     url: sprintf(urls.BUC_GET_SAKTYPE_URL, { sakId, aktoerId }),
-    expectedPayload: mockSakType,
+    expectedPayload: { result: mockSakType, status: 'OK' },
     cascadeFailureError: true,
     type: {
       request: types.BUC_GET_SAKTYPE_REQUEST,

--- a/src/actions/person.ts
+++ b/src/actions/person.ts
@@ -66,7 +66,7 @@ export const getUFT = (vedtakId: string) => {
   return call({
     url: sprintf(urls.PERSON_UFT_URL, { vedtakId }),
     cascadeFailureError: true,
-    expectedPayload: mockUFT,
+    expectedPayload: { result: mockUFT, status: 'OK' },
     type: {
       request: types.PERSON_UFT_REQUEST,
       success: types.PERSON_UFT_SUCCESS,

--- a/src/reducers/app.ts
+++ b/src/reducers/app.ts
@@ -191,11 +191,11 @@ const appReducer = (state: AppState = initialAppState, action: AnyAction) => {
     case types.BUC_GET_SAKTYPE_SUCCESS:
 
       newParams = _.cloneDeep(state.params)
-      if (!_.isNil(action.payload.sakType)) {
-        if (action.payload.sakType.length === 0) {
+      if (!_.isNil(action.payload.result) && !_.isNil(action.payload.result.sakType)) {
+        if (action.payload.result.sakType.length === 0) {
           newParams.sakType = SakTypeMap.UKJENT
         } else {
-          newParams.sakType = SakTypeMap[action.payload.sakType as SakTypeKey]
+          newParams.sakType = SakTypeMap[action.payload.result.sakType as SakTypeKey]
         }
       }
 

--- a/src/reducers/buc.ts
+++ b/src/reducers/buc.ts
@@ -659,7 +659,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
     case types.BUC_GET_KRAVDATO_SUCCESS:
       return {
         ...state,
-        kravDato: (action as ActionWithPayload).payload.kravDato
+        kravDato: (action as ActionWithPayload).payload.result.kravDato
       }
 
     case types.BUC_GET_INSTITUTION_LIST_SUCCESS: {

--- a/src/reducers/person.test.ts
+++ b/src/reducers/person.test.ts
@@ -302,7 +302,7 @@ describe('reducers/person', () => {
   it('PERSON_UFT_SUCCESS with valid dates', () => {
     const result = personReducer(initialPersonState, {
       type: types.PERSON_UFT_SUCCESS,
-      payload: mockUFT
+      payload: { result: mockUFT, status: 'OK' }
     })
 
     expect(result).toEqual({
@@ -323,8 +323,11 @@ describe('reducers/person', () => {
     const result = personReducer(initialPersonState, {
       type: types.PERSON_UFT_SUCCESS,
       payload: {
-        uforetidspunkt: null,
-        virkningstidspunkt: null
+        result: {
+          uforetidspunkt: null,
+          virkningstidspunkt: null
+        },
+        status: 'OK'
       }
     })
 

--- a/src/reducers/person.ts
+++ b/src/reducers/person.ts
@@ -147,13 +147,13 @@ const personReducer = (state: PersonState = initialPersonState, action: AnyActio
     case types.PERSON_UFT_SUCCESS: {
       let uforetidspunkt, virkningstidspunkt
       try {
-        uforetidspunkt = dayjs((action as ActionWithPayload).payload.uforetidspunkt, 'YYYY-MM-DD').toDate()
+        uforetidspunkt = dayjs((action as ActionWithPayload).payload.result.uforetidspunkt, 'YYYY-MM-DD').toDate()
       } catch (e) {
         uforetidspunkt = null
       }
 
       try {
-        virkningstidspunkt = dayjs((action as ActionWithPayload).payload.virkningstidspunkt, 'YYYY-MM-DD').toDate()
+        virkningstidspunkt = dayjs((action as ActionWithPayload).payload.result.virkningstidspunkt, 'YYYY-MM-DD').toDate()
       } catch (e) {
         virkningstidspunkt = null
       }


### PR DESCRIPTION
## Summary

The backend `PensjonController` (`eessi-pensjon-fagmodul`) is being migrated to wrap responses in `FrontEndResponse<T>` (`{ result, status, message, stackTrace }`). This updates the frontend to read `.payload.result` instead of `.payload` for the three PensjonController-backed endpoints, matching how `BucController` / `EuxController` / `PrefillController` / `SedController` responses are already handled.

| Action | File | URL constant |
|--------|------|--------------|
| `getSakType` | `src/actions/buc.ts` | `BUC_GET_SAKTYPE_URL` |
| `fetchKravDato` | `src/actions/buc.ts` | `BUC_GET_KRAVDATO_URL` |
| `getUFT` | `src/actions/person.ts` | `PERSON_UFT_URL` |

## Changes

### Reducers
- `reducers/app.ts` — `BUC_GET_SAKTYPE_SUCCESS` reads `sakType` from `payload.result` (guards `payload.result` for null).
- `reducers/buc.ts` — `BUC_GET_KRAVDATO_SUCCESS` reads `kravDato` from `payload.result`.
- `reducers/person.ts` — `PERSON_UFT_SUCCESS` reads `uforetidspunkt` / `virkningstidspunkt` from `payload.result`.

### Action mocks
- `actions/buc.ts` — `fetchKravDato` and `getSakType` `expectedPayload` wrapped in `{ result, status: 'OK' }` (raw mock files kept importable elsewhere).
- `actions/person.ts` — `getUFT` `expectedPayload` wrapped in `{ result, status: 'OK' }`.

### Tests
- `reducers/person.test.ts` — both `PERSON_UFT_SUCCESS` test payloads wrapped in `{ result, status: 'OK' }`.

### Notes
- Output state shape is unchanged (`kravDato`, `params.sakType`, `uforetidspunkt` / `virkningstidspunkt` written the same way), so components/selectors reading these slices need no changes.
- Failure paths stay driven by HTTP status codes (backend keeps returning 404/400), so `*_FAILURE` handling is unchanged.
- `reducers/loading.ts` handlers only toggle boolean flags — no change needed.

## Verification
- ✅ `npm run typecheck`
- ✅ `npm run test:filtered` — 50 suites, 444 tests passing

## Deploy order
⚠️ **Backend first**, then frontend. Depends on `navikt/eessi-pensjon-fagmodul#552` (PensjonController → FrontEndResponse).

Follows the same pattern as #421 (PrefillController) and #433 (SedController) frontend migrations.

Closes #501
