### PR TITLE
u - Bump js-yaml and brace-expansion to patch DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3953,9 +3953,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7843,9 +7843,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Lockfile-only security refresh closing 3 of the 4 open Dependabot alerts.

## Changes

| Package | From | To | Scope |
|---|---|---|---|
| `js-yaml` | 3.14.2 | 3.15.1 | dev (transitive) |
| `brace-expansion` | 1.1.15 | 1.1.18 | dev (transitive) |

Diff is **6 insertions / 6 deletions in `package-lock.json`** and nothing else. Both declared ranges (`^3.13.1`, `^1.1.7`) already permitted the patched versions — the lockfile was simply stale — so `npm update js-yaml brace-expansion` was sufficient and no `package.json` or `overrides` change was needed.

## Alerts resolved

| # | Sev | Advisory |
|---|---|---|
| 146 | High | [`GHSA-52cp-r559-cp3m`](https://github.com/advisories/GHSA-52cp-r559-cp3m) — js-yaml: YAML merge-key chains force quadratic CPU consumption |
| 144 | Medium | [`GHSA-h67p-54hq-rp68`](https://github.com/advisories/GHSA-h67p-54hq-rp68) — js-yaml: quadratic-complexity DoS via repeated aliases |
| 145 | High | [`GHSA-3jxr-9vmj-r5cp`](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) — brace-expansion: DoS via exponential-time expansion of consecutive `{}` groups |

`npm audit` reports **0** remaining issues for these two packages.

### Why 1.1.18 and not the suggested 1.1.16

Dependabot suggests `brace-expansion@1.1.16`, but that version still leaves `GHSA-mh99-v99m-4gvg` and `GHSA-rgw5-rvv9-x895` open (both previously auto-dismissed as dev-scope). `1.1.18` is the head of the `maintenance-v1` line and clears all three — verified via `npm audit` on both candidates.

## Risk assessment: negligible

- Both are **patch releases within the same major** (js-yaml 3.x maintenance, brace-expansion v1 maintenance) — no API changes.
- Both are **dev-only** and are **not bundled into the Vite build**. Only one copy of each exists in the tree. Reachable exclusively through Jest:

```
jest 29.7.0 -> jest-config
  |- babel-jest -> babel-plugin-istanbul@6 -> @istanbuljs/load-nyc-config -> js-yaml@^3
  `- glob@7 -> minimatch@3 -> brace-expansion@^1
```

- Real-world exposure was limited to parsing attacker-controlled YAML/globs at test time, i.e. effectively zero here. This is hygiene, not incident response.

## Verification

| Command | Result |
|---|---|
| `npm ci` | OK |
| `npm run typecheck` | PASS — no compiler errors |
| `npm run test:filtered` | PASS — 51/51 suites, 476/476 tests |
| `npm run build` | PASS — 3512 modules transformed |

## Out of scope (deliberately)

- **`react-router` [`GHSA-qwww-vcr4-c8h2`](https://github.com/advisories/GHSA-qwww-vcr4-c8h2) (alert #147)** — dismissed separately as *not affected*. The advisory states it "only affects your application if you are using the unstable RSC APIs"; this app is a client-side SPA using `BrowserRouter`/`Routes`/`Route`, with no `unstable_*`, `/rsc` or `@vitejs/plugin-rsc` references in `src/`, `vite.config.*` or `server.mjs`. There is no fix on the 7.x line (patched only in `react-router@8.3.0`), and `react-router-dom` has no v8 — its `latest` is frozen at `7.18.2` — so remediation requires migrating every import from `react-router-dom` to `react-router` plus confirming the Docker base image is Node >= 22.22.0. Backlog item.
- **`jest` 29 -> 30** would also have cleared these three natively, and would fix the existing `jest@29.7.0` / `jest-environment-jsdom@30.4.1` major-version mismatch — but that is a test-suite-wide major upgrade and shouldn't be coupled to a security patch. Separate ticket.
