### PR TITLE
Handle FrontendResponse wrapper from StorageController endpoints

### DIFF
--- a/src/actions/buc.test.ts
+++ b/src/actions/buc.test.ts
@@ -9,6 +9,8 @@ import { Buc, NewBucPayload, NewSedPayload, SakTypeValue, Sed, SEDAttachmentPayl
 import { JoarkBrowserItem } from 'src/declarations/joark'
 import { call as originalCall } from '@navikt/fetch'
 import _ from 'lodash'
+import mockBucsInfo from 'src/mocks/buc/bucsInfo'
+import mockBucsInfoList from 'src/mocks/buc/bucsInfoList'
 import mockItems from 'src/mocks/joark/items'
 
 jest.mock('@navikt/fetch', () => ({
@@ -155,6 +157,7 @@ describe('src/actions/buc', () => {
         success: types.BUC_GET_BUCSINFO_SUCCESS,
         failure: types.BUC_GET_BUCSINFO_FAILURE
       },
+      expectedPayload: { result: mockBucsInfo, status: 'OK' },
       url: sprintf(urls.API_STORAGE_GET_URL, { userId: mockUserId, namespace: mockNamespace, file: mockFilename })
     }))
   })
@@ -168,6 +171,7 @@ describe('src/actions/buc', () => {
         success: types.BUC_GET_BUCSINFO_LIST_SUCCESS,
         failure: types.BUC_GET_BUCSINFO_LIST_FAILURE
       },
+      expectedPayload: { result: mockBucsInfoList(mockUserId), status: 'OK' },
       url: sprintf(urls.API_STORAGE_LIST_URL, { userId: mockUserId, namespace: storage.NAMESPACE_BUC })
     }))
   })

--- a/src/actions/buc.ts
+++ b/src/actions/buc.ts
@@ -200,7 +200,7 @@ export const fetchBucsInfo = (
 ): ActionWithPayload<BucsInfoRawList> => {
   return call({
     url: sprintf(urls.API_STORAGE_GET_URL, { userId, namespace, file }),
-    expectedPayload: mockBucsInfo,
+    expectedPayload: { result: mockBucsInfo, status: 'OK' },
     type: {
       request: types.BUC_GET_BUCSINFO_REQUEST,
       success: types.BUC_GET_BUCSINFO_SUCCESS,
@@ -214,7 +214,7 @@ export const fetchBucsInfoList = (
 ): ActionWithPayload<BucsInfoRawList> => {
   return call({
     url: sprintf(urls.API_STORAGE_LIST_URL, { userId: aktoerId, namespace: storage.NAMESPACE_BUC }),
-    expectedPayload: mockBucsInfoList(aktoerId),
+    expectedPayload: { result: mockBucsInfoList(aktoerId), status: 'OK' },
     type: {
       request: types.BUC_GET_BUCSINFO_LIST_REQUEST,
       success: types.BUC_GET_BUCSINFO_LIST_SUCCESS,

--- a/src/actions/p5000.test.ts
+++ b/src/actions/p5000.test.ts
@@ -1,10 +1,12 @@
 import * as p5000Actions from 'src/actions/p5000'
 import * as types from 'src/constants/actionTypes'
+import * as storage from 'src/constants/storage'
 import * as urls from 'src/constants/urls'
 import { Sed } from 'src/declarations/buc'
 import { P5000SED } from 'src/declarations/p5000'
 import { call as originalCall } from '@navikt/fetch'
 import mockSedP5000 from 'src/mocks/buc/sed_P5000_small1'
+import mockP5000FromS3 from 'src/mocks/p5000/fromS3'
 
 const sprintf = require('sprintf-js').sprintf
 jest.mock('@navikt/fetch', () => ({
@@ -56,6 +58,21 @@ describe('actions/p5000', () => {
         failure: types.SED_P5000_SEND_FAILURE
       },
       url: sprintf(urls.SED_P5000_PUT_URL, { caseId: mockCaseId, sedId: mockSedId })
+    }))
+  })
+
+  it('getP5000FromS3()', () => {
+    const mockFnr = '123'
+    const mockCaseId = '456'
+    p5000Actions.getP5000FromS3(mockFnr, mockCaseId)
+    expect(call).toHaveBeenCalledWith(expect.objectContaining({
+      type: {
+        request: types.P5000_PESYS_GET_REQUEST,
+        success: types.P5000_PESYS_GET_SUCCESS,
+        failure: types.P5000_PESYS_GET_FAILURE
+      },
+      expectedPayload: { result: mockP5000FromS3, status: 'OK' },
+      url: sprintf(urls.API_STORAGE_GET_URL, { userId: mockFnr, namespace: storage.NAMESPACE_PESYS, file: mockCaseId })
     }))
   })
 })

--- a/src/actions/p5000.ts
+++ b/src/actions/p5000.ts
@@ -70,7 +70,7 @@ export const getP5000FromS3 = (
     method: 'GET',
     cascadeFailureError: true,
     expectedErrorRate: { 200: 1 },
-    expectedPayload: mockP5000FromS3,
+    expectedPayload: { result: mockP5000FromS3, status: 'OK' },
     type: {
       request: types.P5000_PESYS_GET_REQUEST,
       success: types.P5000_PESYS_GET_SUCCESS,

--- a/src/reducers/buc.test.ts
+++ b/src/reducers/buc.test.ts
@@ -363,7 +363,7 @@ describe('reducers/buc', () => {
     expect(
       bucReducer(initialBucState, {
         type: types.BUC_GET_BUCSINFO_SUCCESS,
-        payload: '{"foo": "bar"}'
+        payload: { result: '{"foo": "bar"}', status: 'OK' }
       })
     ).toEqual({
       ...initialBucState,
@@ -406,11 +406,12 @@ describe('reducers/buc', () => {
   it('BUC_GET_BUCSINFO_LIST_SUCCESS', () => {
     expect(
       bucReducer(initialBucState, {
-        type: types.BUC_GET_BUCSINFO_LIST_SUCCESS
+        type: types.BUC_GET_BUCSINFO_LIST_SUCCESS,
+        payload: { result: ['mockBucsInfoList'], status: 'OK' }
       })
     ).toEqual({
       ...initialBucState,
-      bucsInfoList: undefined
+      bucsInfoList: ['mockBucsInfoList']
     })
   })
 

--- a/src/reducers/buc.ts
+++ b/src/reducers/buc.ts
@@ -594,12 +594,13 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
         bucOptions: []
       }
 
-    case types.BUC_GET_BUCSINFO_SUCCESS:
-
+    case types.BUC_GET_BUCSINFO_SUCCESS: {
+      const payload = (action as ActionWithPayload).payload.result
       return {
         ...state,
-        bucsInfo: typeof (action as ActionWithPayload).payload === 'object' ? (action as ActionWithPayload).payload : JSON.parse((action as ActionWithPayload).payload)
+        bucsInfo: typeof payload === 'object' ? payload : JSON.parse(payload)
       }
+    }
 
     case types.BUC_GET_BUCSINFO_REQUEST:
     case types.BUC_GET_BUCSINFO_FAILURE:
@@ -613,7 +614,7 @@ const bucReducer = (state: BucState = initialBucState, action: AnyAction) => {
 
       return {
         ...state,
-        bucsInfoList: (action as ActionWithPayload).payload
+        bucsInfoList: (action as ActionWithPayload).payload.result
       }
 
     case types.BUC_GET_BUCSINFO_LIST_REQUEST:

--- a/src/reducers/p5000.test.ts
+++ b/src/reducers/p5000.test.ts
@@ -2,8 +2,21 @@ import * as types from 'src/constants/actionTypes'
 import p5000Reducer, { initialP5000State } from 'src/reducers/p5000'
 import mockSed1 from 'src/mocks/buc/sed_P5000_small1'
 import mockSed2 from 'src/mocks/buc/sed_P5000_small2'
+import mockP5000FromS3 from 'src/mocks/p5000/fromS3'
 
 describe('reducers/p5000', () => {
+  it('P5000_PESYS_GET_SUCCESS', () => {
+    expect(
+      p5000Reducer(initialP5000State, {
+        type: types.P5000_PESYS_GET_SUCCESS,
+        payload: { result: mockP5000FromS3, status: 'OK' }
+      })
+    ).toEqual({
+      ...initialP5000State,
+      p5000sFromS3: mockP5000FromS3
+    })
+  })
+
   it('SED_P5000_GET_SUCCESS', () => {
     expect(
       p5000Reducer({

--- a/src/reducers/p5000.ts
+++ b/src/reducers/p5000.ts
@@ -133,7 +133,7 @@ const p5000Reducer = (state: P5000State = initialP5000State, action: AnyAction):
     case types.P5000_PESYS_GET_SUCCESS: {
       return {
         ...state,
-        p5000sFromS3: (action as ActionWithPayload).payload
+        p5000sFromS3: (action as ActionWithPayload).payload.result
       }
     }
 


### PR DESCRIPTION
Closes #504

Consumes the StorageController FrontEndResponse wrapper in BUC and P5000 reducers, and updates development/test mock payloads.

Depends on navikt/eessi-pensjon-saksbehandling-api#143. Deploy backend before frontend.